### PR TITLE
Removing set of numpy random seed

### DIFF
--- a/GPy/examples/dimensionality_reduction.py
+++ b/GPy/examples/dimensionality_reduction.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2012, GPy authors (see AUTHORS.txt).
 # Licensed under the BSD 3-clause license (see LICENSE.txt)
 import numpy as _np
-default_seed = _np.random.seed(123344)
+default_seed = 123344
 
 def bgplvm_test_model(seed=default_seed, optimize=False, verbose=1, plot=False):
     """


### PR DESCRIPTION
This caused me some confusion when I started using GPy in my project. I noticed that after importing GPy, my code produced the same output every time. I traced it back to a call to `np.random.seed` in one of the imported examples. This doesn't seem like the desired behavior. 
