### PR TITLE
Kernel product bugfix

### DIFF
--- a/GPy/kern/_src/prod.py
+++ b/GPy/kern/_src/prod.py
@@ -5,7 +5,6 @@ import numpy as np
 from kern import CombinationKernel
 from ...util.caching import Cache_this
 import itertools
-import operator
 
 
 def numpy_invalid_op_as_exception(func):
@@ -64,7 +63,7 @@ class Prod(CombinationKernel):
         except FloatingPointError:
             #print "WARNING: gradient calculation falling back to slow version due to zero-valued kernel"
             for combination in itertools.combinations(self.parts, len(self.parts) - 1):
-                prod = reduce(operator.mul, [p.K(X, X2) for p in combination])
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination])
                 to_update = list(set(self.parts) - set(combination))[0]
                 to_update.update_gradients_full(dL_dK * prod, X, X2)
 

--- a/GPy/kern/_src/prod.py
+++ b/GPy/kern/_src/prod.py
@@ -61,7 +61,6 @@ class Prod(CombinationKernel):
             for p in self.parts:
                 p.update_gradients_full(k/p.K(X,X2),X,X2)
         except FloatingPointError:
-            #print "WARNING: gradient calculation falling back to slow version due to zero-valued kernel"
             for combination in itertools.combinations(self.parts, len(self.parts) - 1):
                 prod = reduce(np.multiply, [p.K(X, X2) for p in combination])
                 to_update = list(set(self.parts) - set(combination))[0]

--- a/GPy/testing/kernel_tests.py
+++ b/GPy/testing/kernel_tests.py
@@ -400,12 +400,27 @@ class Coregionalize_weave_test(unittest.TestCase):
     #reset the weave state for any other tests
     GPy.util.config.config.set('weave', 'working', 'False')
 
+class KernelTestsProductWithZeroValues(unittest.TestCase):
+
+    def test_zero_valued_kernel(self):
+        X = np.array([[0,1],[1,0]])
+        Y = np.array([[1],[10]])
+        lin = GPy.kern.Linear(2)
+        bias = GPy.kern.Bias(2)
+        k = lin * bias
+        #k = lin
+        m = GPy.models.GPRegression(X, Y, kernel=k)
+        #m['mul.bias.variance'].constrain_fixed(0)
+        m.optimize(messages=False)
 
 
 
 if __name__ == "__main__":
     print "Running unit tests, please be (very) patient..."
     unittest.main()
+    #suite = unittest.TestLoader().loadTestsFromTestCase(KernelTestsProductWithZeroValues)
+    #unittest.TextTestRunner().run(suite)
+
 #     np.random.seed(0)
 #     N0 = 3
 #     N1 = 9

--- a/GPy/testing/kernel_tests.py
+++ b/GPy/testing/kernel_tests.py
@@ -408,10 +408,11 @@ class KernelTestsProductWithZeroValues(unittest.TestCase):
         lin = GPy.kern.Linear(2)
         bias = GPy.kern.Bias(2)
         k = lin * bias
-        #k = lin
         m = GPy.models.GPRegression(X, Y, kernel=k)
-        #m['mul.bias.variance'].constrain_fixed(0)
-        m.optimize(messages=False)
+        try:
+            m.optimize()
+        except np.linalg.LinAlgError:
+            self.fail("Zero-valued kernel raised exception!")
 
 
 

--- a/GPy/testing/kernel_tests.py
+++ b/GPy/testing/kernel_tests.py
@@ -408,11 +408,9 @@ class KernelTestsProductWithZeroValues(unittest.TestCase):
         lin = GPy.kern.Linear(2)
         bias = GPy.kern.Bias(2)
         k = lin * bias
-        m = GPy.models.GPRegression(X, Y, kernel=k)
-        try:
-            m.optimize()
-        except np.linalg.LinAlgError:
-            self.fail("Zero-valued kernel raised exception!")
+        k.update_gradients_full(1, X)
+        self.assertFalse(np.isnan(k['linear.variances'].gradient),
+                         "Gradient resulted in NaN")
 
 
 

--- a/GPy/testing/kernel_tests.py
+++ b/GPy/testing/kernel_tests.py
@@ -400,25 +400,27 @@ class Coregionalize_weave_test(unittest.TestCase):
     #reset the weave state for any other tests
     GPy.util.config.config.set('weave', 'working', 'False')
 
+
 class KernelTestsProductWithZeroValues(unittest.TestCase):
 
-    def test_zero_valued_kernel(self):
-        X = np.array([[0,1],[1,0]])
-        Y = np.array([[1],[10]])
-        lin = GPy.kern.Linear(2)
-        bias = GPy.kern.Bias(2)
-        k = lin * bias
-        k.update_gradients_full(1, X)
-        self.assertFalse(np.isnan(k['linear.variances'].gradient),
+    def setUp(self):
+        self.X = np.array([[0,1],[1,0]])
+        self.k = GPy.kern.Linear(2) * GPy.kern.Bias(2)
+
+    def test_zero_valued_kernel_full(self):
+        self.k.update_gradients_full(1, self.X)
+        self.assertFalse(np.isnan(self.k['linear.variances'].gradient),
                          "Gradient resulted in NaN")
 
+    def test_zero_valued_kernel_gradients_X(self):
+        target = self.k.gradients_X(1, self.X)
+        self.assertFalse(np.any(np.isnan(target)),
+                         "Gradient resulted in NaN")
 
 
 if __name__ == "__main__":
     print "Running unit tests, please be (very) patient..."
     unittest.main()
-    #suite = unittest.TestLoader().loadTestsFromTestCase(KernelTestsProductWithZeroValues)
-    #unittest.TextTestRunner().run(suite)
 
 #     np.random.seed(0)
 #     N0 = 3


### PR DESCRIPTION
A bugfix to prevent a zero division in kernel products when one or more kernel evaluations result in zero. Added two tests: one for update_gradients_full and another one for gradients_X.