### PR TITLE
matplotlib interactive mode only in IPython

### DIFF
--- a/GPy/plotting/matplot_dep/maps.py
+++ b/GPy/plotting/matplot_dep/maps.py
@@ -9,7 +9,7 @@ try:
     try:
         __IPYTHON__
         pb.ion()
-    except:
+    except NameError:
         pass
 except:
     pass

--- a/GPy/plotting/matplot_dep/maps.py
+++ b/GPy/plotting/matplot_dep/maps.py
@@ -6,7 +6,11 @@ try:
     from matplotlib.patches import Polygon
     from matplotlib.collections import PatchCollection
     #from matplotlib import cm
-    pb.ion()
+    try:
+        __IPYTHON__
+        pb.ion()
+    except:
+        pass
 except:
     pass
 import re


### PR DESCRIPTION
This is cometic but it I find it useful.
The change means that matplotlib intractive mode is only turned on in IPython. 
This is so that running a python script that imports GPy and matplotlib and is invoked via python rather than IPython behaves like expected.