### PR TITLE
Fix print statement

### DIFF
--- a/GPy/inference/mcmc/samplers.py
+++ b/GPy/inference/mcmc/samplers.py
@@ -1,6 +1,6 @@
 # ## Copyright (c) 2014, Zhenwen Dai
 # Licensed under the BSD 3-clause license (see LICENSE.txt)
-
+from __future__ import print_function
 
 import numpy as np
 from scipy import linalg, optimize


### PR DESCRIPTION
I noticed there is a small incompatibility between Python 2 and 3, as it is using `print` with kwargs, which is a syntax error in Python 2.