### PR TITLE
Cross Platform Cython Fixes

### DIFF
--- a/GPy/kern/_src/coregionalize.py
+++ b/GPy/kern/_src/coregionalize.py
@@ -5,7 +5,6 @@ from .kern import Kern
 import numpy as np
 from ...core.parameterization import Param
 from ...core.parameterization.transformations import Logexp
-from ...util.config import config # for assesing whether to use cython
 try:
     from . import coregionalize_cython
     cython_available = True
@@ -84,7 +83,7 @@ class Coregionalize(Kern):
     def Kdiag(self, X):
         return np.diag(self.B)[np.asarray(X, dtype=np.int).flatten()]
 
-    def update_gradients_full(self, dL_dK, X, X2=None):
+    def update_gradients_full(self, dL_dK, X, X2=None,cython=False):
         index = np.asarray(X, dtype=np.int)
         if X2 is None:
             index2 = index
@@ -92,7 +91,7 @@ class Coregionalize(Kern):
             index2 = np.asarray(X2, dtype=np.int)
 
         #attempt to use cython for a nasty double indexing loop: fall back to numpy
-        if config.getboolean('cython', 'working'):
+        if cython_available:
             dL_dK_small = self._gradient_reduce_cython(dL_dK, index, index2)
         else:
             dL_dK_small = self._gradient_reduce_numpy(dL_dK, index, index2)

--- a/GPy/kern/_src/coregionalize.py
+++ b/GPy/kern/_src/coregionalize.py
@@ -6,7 +6,11 @@ import numpy as np
 from ...core.parameterization import Param
 from ...core.parameterization.transformations import Logexp
 from ...util.config import config # for assesing whether to use cython
-from . import coregionalize_cython
+try:
+    from . import coregionalize_cython
+    cython_available = True
+except ImportError:
+    cython_available = False
 
 class Coregionalize(Kern):
     """
@@ -57,7 +61,7 @@ class Coregionalize(Kern):
         self.B = np.dot(self.W, self.W.T) + np.diag(self.kappa)
 
     def K(self, X, X2=None):
-        if config.getboolean('cython', 'working'):
+        if cython_available:
             return self._K_cython(X, X2)
         else:
             return self._K_numpy(X, X2)
@@ -126,4 +130,3 @@ class Coregionalize(Kern):
 
     def gradients_X_diag(self, dL_dKdiag, X):
         return np.zeros(X.shape)
-

--- a/GPy/kern/_src/stationary.py
+++ b/GPy/kern/_src/stationary.py
@@ -14,9 +14,9 @@ from ...util.caching import Cache_this
 
 try:
     from . import stationary_cython
+    cython_available = True
 except ImportError:
-    print('warning in stationary: failed to import cython module: falling back to numpy')
-    config.set('cython', 'working', 'false')
+    cython_available = False
 
 
 class Stationary(Kern):
@@ -172,7 +172,7 @@ class Stationary(Kern):
 
             tmp = dL_dr*self._inv_dist(X, X2)
             if X2 is None: X2 = X
-            if config.getboolean('cython', 'working'):
+            if cython_available:
                 self.lengthscale.gradient = self._lengthscale_grads_cython(tmp, X, X2)
             else:
                 self.lengthscale.gradient = self._lengthscale_grads_pure(tmp, X, X2)
@@ -205,7 +205,7 @@ class Stationary(Kern):
         """
         Given the derivative of the objective wrt K (dL_dK), compute the derivative wrt X
         """
-        if config.getboolean('cython', 'working'):
+        if cython_available:
             return self._gradients_X_cython(dL_dK, X, X2)
         else:
             return self._gradients_X_pure(dL_dK, X, X2)
@@ -499,5 +499,3 @@ class RatQuad(Stationary):
     def update_gradients_diag(self, dL_dKdiag, X):
         super(RatQuad, self).update_gradients_diag(dL_dKdiag, X)
         self.power.gradient = 0.
-
-

--- a/GPy/kern/_src/stationary_utils.h
+++ b/GPy/kern/_src/stationary_utils.h
@@ -1,3 +1,5 @@
+#ifndef __APPLE__
 #include <omp.h>
+#endif
 void _grad_X(int N, int D, int M, double*X, double* X2, double* tmp, double* grad);
 void _lengthscale_grads(int N, int D, int M, double* X, double* X2, double* tmp, double* grad);

--- a/GPy/testing/cython_tests.py
+++ b/GPy/testing/cython_tests.py
@@ -1,12 +1,19 @@
 import numpy as np
+import unittest
 import scipy as sp
 from GPy.util import choleskies
 import GPy
+try:
+    from . import choleskies_cython
+    cython_available = True
+except ImportError:
+    cython_available = False
+
 
 """
-These tests make sure that the opure python and cython codes work the same
+These tests make sure that the pure python and cython codes work the same. If Cython is not available, they will be skipped.
 """
-
+@unittest.skipIf(~cython_available,"Cython modules have not been built on this machine")
 class CythonTestChols(np.testing.TestCase):
     def setUp(self):
         self.flat = np.random.randn(45,5)
@@ -20,6 +27,7 @@ class CythonTestChols(np.testing.TestCase):
         A2 = choleskies._triang_to_flat_cython(self.triang)
         np.testing.assert_allclose(A1, A2)
 
+@unittest.skipIf(~cython_available,"Cython modules have not been built on this machine")
 class test_stationary(np.testing.TestCase):
     def setUp(self):
         self.k = GPy.kern.RBF(10)
@@ -49,6 +57,7 @@ class test_stationary(np.testing.TestCase):
         g2 = self.k._lengthscale_grads_cython(self.dKxz, self.X, self.Z)
         np.testing.assert_allclose(g1, g2)
 
+@unittest.skipIf(~cython_available,"Cython modules have not been built on this machine")
 class test_choleskies_backprop(np.testing.TestCase):
     def setUp(self):
         a =np.random.randn(10,12)
@@ -61,10 +70,3 @@ class test_choleskies_backprop(np.testing.TestCase):
         r3 = GPy.util.choleskies.choleskies_cython.backprop_gradient_par_c(self.dL, self.L)
         np.testing.assert_allclose(r1, r2)
         np.testing.assert_allclose(r1, r3)
-
-
-
-
-
-
-

--- a/GPy/testing/cython_tests.py
+++ b/GPy/testing/cython_tests.py
@@ -3,17 +3,13 @@ import unittest
 import scipy as sp
 from GPy.util import choleskies
 import GPy
-try:
-    from . import choleskies_cython
-    cython_available = True
-except ImportError:
-    cython_available = False
 
+cython_available=choleskies.cython_available
 
 """
 These tests make sure that the pure python and cython codes work the same. If Cython is not available, they will be skipped.
 """
-@unittest.skipIf(~cython_available,"Cython modules have not been built on this machine")
+@unittest.skipIf(not cython_available,"Cython modules have not been built on this machine")
 class CythonTestChols(np.testing.TestCase):
     def setUp(self):
         self.flat = np.random.randn(45,5)
@@ -27,7 +23,7 @@ class CythonTestChols(np.testing.TestCase):
         A2 = choleskies._triang_to_flat_cython(self.triang)
         np.testing.assert_allclose(A1, A2)
 
-@unittest.skipIf(~cython_available,"Cython modules have not been built on this machine")
+@unittest.skipIf(not cython_available,"Cython modules have not been built on this machine")
 class test_stationary(np.testing.TestCase):
     def setUp(self):
         self.k = GPy.kern.RBF(10)
@@ -57,7 +53,7 @@ class test_stationary(np.testing.TestCase):
         g2 = self.k._lengthscale_grads_cython(self.dKxz, self.X, self.Z)
         np.testing.assert_allclose(g1, g2)
 
-@unittest.skipIf(~cython_available,"Cython modules have not been built on this machine")
+@unittest.skipIf(not cython_available,"Cython modules have not been built on this machine")
 class test_choleskies_backprop(np.testing.TestCase):
     def setUp(self):
         a =np.random.randn(10,12)

--- a/GPy/util/choleskies.py
+++ b/GPy/util/choleskies.py
@@ -4,8 +4,11 @@
 import numpy as np
 from . import linalg
 from .config import config
-
-from . import choleskies_cython
+try:
+    from . import choleskies_cython
+    cython_available = True
+except ImportError:
+    cython_available = False
 
 def safe_root(N):
     i = np.sqrt(N)
@@ -97,7 +100,7 @@ def indexes_to_fix_for_low_rank(rank, size):
     return np.setdiff1d(np.arange((size**2+size)/2), keep)
 
 
-if config.getboolean('cython', 'working'):
+if cython_available:
     triang_to_flat = _triang_to_flat_cython
     flat_to_triang = _flat_to_triang_cython
     backprop_gradient = choleskies_cython.backprop_gradient_par_c

--- a/GPy/util/linalg.py
+++ b/GPy/util/linalg.py
@@ -11,7 +11,11 @@ from scipy.linalg import lapack, blas
 
 from .config import config
 import logging
-from . import linalg_cython
+try:
+    from . import linalg_cython
+    cython_available = True
+except ImportError:
+    cython_available = False
 
 
 def force_F_ordered_symmetric(A):
@@ -358,7 +362,7 @@ def symmetrify(A, upper=False):
 
     note: tries to use cython, falls back to a slower numpy version
     """
-    if config.getboolean('cython', 'working'):
+    if cython_available:
         _symmetrify_cython(A, upper)
     else:
         _symmetrify_numpy(A, upper)

--- a/setup.py
+++ b/setup.py
@@ -12,18 +12,31 @@ version = '0.6.1'
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-#compile_flags = ["-march=native", '-fopenmp', '-O3', ]
-compile_flags = [ '-fopenmp', '-O3', ]
+#Mac OS X Clang doesn't support OpenMP th the current time.
+#This detects if we are building on a Mac
+def ismac():
+    platform = sys.platform
+    ismac = False
+    if platform[:6] == 'darwin':
+        ismac = True
+    return ismac
+
+if ismac():
+    compile_flags = [ '-O3', ]
+    link_args = ['']
+else:
+    compile_flags = [ '-fopenmp', '-O3', ]
+    link_args = ['-lgomp']
 
 ext_mods = [Extension(name='GPy.kern._src.stationary_cython',
                       sources=['GPy/kern/_src/stationary_cython.c','GPy/kern/_src/stationary_utils.c'],
                       include_dirs=[np.get_include()],
                       extra_compile_args=compile_flags,
-                      extra_link_args = ['-lgomp']),
+                      extra_link_args = link_args),
             Extension(name='GPy.util.choleskies_cython',
                       sources=['GPy/util/choleskies_cython.c'],
                       include_dirs=[np.get_include()],
-                      extra_link_args = ['-lgomp'],
+                      extra_link_args = link_args,
                       extra_compile_args=compile_flags),
             Extension(name='GPy.util.linalg_cython',
                       sources=['GPy/util/linalg_cython.c'],


### PR DESCRIPTION
I don't think that the mechanism we were attempting to use to detect a lack of Cython-built modules was working properly so I've changed it. There is some tidying up left to do and a few cross-platform issues have been exposed (I'll open the issues later) but this at least allows the test suite to be run even when Cython modules are not built.

If the Cython modules are not built, all functions fall back to the pure Python or Python+numpy implementations. The Cython-specific tests are skipped.

On Ubuntu, on a fresh git clone:

nosetests ./GPy/testing/
SSSSSSS......... /home/walkingrandomly/GPy/GPy/core/parameterization/transformations.py:77: RuntimeWarning:invalid value encountered in greater
 /home/walkingrandomly/GPy/GPy/core/parameterization/transformations.py:82: RuntimeWarning:invalid value encountered in greater
........................................................................................................................................................................................................................................S.S...............................................................
----------------------------------------------------------------------
Ran 314 tests in 12.828s

OK (SKIP=9)

Now, I build Cython modules:

    python setup.py build_ext --inplace

nosetests ./GPy/testing/................ /home/walkingrandomly/GPy/GPy/core/parameterization/transformations.py:77: RuntimeWarning:invalid value encountered in greater
 /home/walkingrandomly/GPy/GPy/core/parameterization/transformations.py:82: RuntimeWarning:invalid value encountered in greater
........................................................................................................................................................................................................................................S.S...............................................................
----------------------------------------------------------------------
Ran 314 tests in 12.340s

OK (SKIP=2)

I deleted a couple of Cython related tests from the kernel testing module. This is because it seemed tricky to propagate the relevant variable through the full calculation without modifying the interface to kernel functions. As such, I may have decreased Cython test coverage (need to check!) but the equivalence of Cython/Python implementations should really be checked more directly anyway IMHO.

I'm not going to merge this change myself since I'd prefer someone else to review and merge (or not).

Cheers,
Mike

Update - Mac OS X Cython support
 I've added fixes so that Cython modules now compile on Mac OS X. Setup.py detects if it's running on a Mac and, if it is, removes references to OpenMP. A similar mechanism is in the .c include header. 

This will be a pain for users of GNU gcc on Mac since they won't get OpenMP even though they have OpenMP but, if they REALLY need it, they can always manually edit the relevant files for now. 

I propose not to worry about this too much since Clang will get OpenMP eventually and we can just remove this stuff.