### PR TITLE
added the gradients_X function for standard periodic kernel

### DIFF
--- a/GPy/kern/_src/standard_periodic.py
+++ b/GPy/kern/_src/standard_periodic.py
@@ -156,11 +156,25 @@ class StdPeriodic(Kern):
         self.wavelengths.gradient = 0
         self.lengthscales.gradient = 0
 
-#    def gradients_X(self, dL_dK, X, X2=None):
-#        """derivative of the covariance matrix with respect to X."""
-#    
+    def gradients_X(self, dL_dK, X, X2=None):
+        """derivative of the covariance matrix with respect to X."""
+        if X2 is None:
+            X2 = X
+
+        base = np.pi * (X[:, None, :] - X2[None, :, :]) / self.wavelengths
+
+        sin_base = np.sin( base )
+        exp_dist = np.exp( -0.5* np.sum( np.square(  sin_base / self.lengthscales ), axis = -1 ) )
+
+        dx = -self.variance * (np.pi / (self.wavelengths*np.square(self.lengthscales))) * sin_base*np.cos(base)
+
+        if self.ARD1:  # different wavelengths
+            return (dx * exp_dist[:,:,None] * dL_dK[:, :, None]).sum(0).sum(0)
+        else:  # same wavelengths
+            return np.sum(dx.sum(-1) * exp_dist * dL_dK)
 #        raise NotImplemented("Periodic kernel: dK_dX not implemented")
 #
-#    def gradients_X_diag(self, dL_dKdiag, X):
-#        
+    def gradients_X_diag(self, dL_dKdiag, X):
+        """derivative of the covariance matrix with respect to X - diagonal."""
+        pass  # diagonal element is zero
 #        raise NotImplemented("Periodic kernel: dKdiag_dX not implemented")


### PR DESCRIPTION
Hi,

Could you review the change I made for the gradients_X function. Need to use it for a sparse GP. The gradient of this kernel w.r.t. X is:
$$
\frac{dK}{dX_i} = -k(X,X_2)\frac{\pi}{l_i^2T_i}\sin\left(\pi\frac{\sum_i(X_i-X_{2i})}{T_i}\right)\cos\left(\pi\frac{\sum_i(X_i-X_{2i})}{T_i}\right)
$$
see [here](http://www.texrendr.com/?eqn=%5Cfrac%7BdK%7D%7BdX_i%7D%20%3D%20-k%28X%2CX_2%29%5Cfrac%7B%5Cpi%7D%7Bl_i%5E2T_i%7D%5Csin%5Cleft%28%5Cpi%5Cfrac%7B%5Csum_i%28X_i-X_%7B2i%7D%29%7D%7BT_i%7D%5Cright%29%5Ccos%5Cleft%28%5Cpi%5Cfrac%7B%5Csum_i%28X_i-X_%7B2i%7D%29%7D%7BT_i%7D%5Cright%29) for rendered LaTeX version.

However, what I am unsure about is this sum() business after multiplying with dL_dK (side note: is this matrix multiplication or element wise mult?). I simply copied that part of it from the `upgrade_gradients_full` function from above this function.

If this is correct I am happy to go and do other functions in a similar fashion.
