### PR TITLE
Fixed inputs and BGPLVM prediction tests

### DIFF
--- a/GPy/plotting/gpy_plot/gp_plots.py
+++ b/GPy/plotting/gpy_plot/gp_plots.py
@@ -235,8 +235,6 @@ def plot_density(self, plot_limits=None, fixed_inputs=None,
 
     Give the Y_metadata in the predict_kw if you need it.
 
-
-
     :param plot_limits: The limits of the plot. If 1D [xmin,xmax], if 2D [[xmin,ymin],[xmax,ymax]]. Defaluts to data limits
     :type plot_limits: np.array
     :param fixed_inputs: a list of tuple [(i,v), (i,v)...], specifying that input dimension i should be set to value v.

--- a/GPy/plotting/matplot_dep/util.py
+++ b/GPy/plotting/matplot_dep/util.py
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright (c) 2015, Max Zwiessele
+# Copyright (c) 2016, Max Zwiessele, Alan saul
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -131,6 +131,7 @@ def fixed_inputs(model, non_fixed_inputs, fix_routine='median', as_list=True, X_
     :param as_list: if true, will return a list of tuples with (dimension, fixed_val) otherwise it will create the corresponding X matrix
     :type as_list: boolean
     """
+    from ...inference.latent_function_inference.posterior import VariationalPosterior
     f_inputs = []
     if hasattr(model, 'has_uncertain_inputs') and model.has_uncertain_inputs():
         X = model.X.mean.values.copy()

--- a/GPy/plotting/matplot_dep/util.py
+++ b/GPy/plotting/matplot_dep/util.py
@@ -117,3 +117,41 @@ def align_subplot_array(axes,xlim=None, ylim=None):
             ax.set_xticks([])
         else:
             removeUpperTicks(ax)
+
+def fixed_inputs(model, non_fixed_inputs, fix_routine='median', as_list=True, X_all=False):
+    """
+    Convenience function for returning back fixed_inputs where the other inputs
+    are fixed using fix_routine
+    :param model: model
+    :type model: Model
+    :param non_fixed_inputs: dimensions of non fixed inputs
+    :type non_fixed_inputs: list
+    :param fix_routine: fixing routine to use, 'mean', 'median', 'zero'
+    :type fix_routine: string
+    :param as_list: if true, will return a list of tuples with (dimension, fixed_val) otherwise it will create the corresponding X matrix
+    :type as_list: boolean
+    """
+    f_inputs = []
+    if hasattr(model, 'has_uncertain_inputs') and model.has_uncertain_inputs():
+        X = model.X.mean.values.copy()
+    elif isinstance(model.X, VariationalPosterior):
+        X = model.X.values.copy()
+    else:
+        if X_all:
+            X = model.X_all.copy()
+        else:
+            X = model.X.copy()
+    for i in range(X.shape[1]):
+        if i not in non_fixed_inputs:
+            if fix_routine == 'mean':
+                f_inputs.append( (i, np.mean(X[:,i])) )
+            if fix_routine == 'median':
+                f_inputs.append( (i, np.median(X[:,i])) )
+            else: # set to zero zero
+                f_inputs.append( (i, 0) )
+            if not as_list:
+                X[:,i] = f_inputs[-1][1]
+    if as_list:
+        return f_inputs
+    else:
+        return X

--- a/GPy/testing/util_tests.py
+++ b/GPy/testing/util_tests.py
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright (c) 2016, Max Zwiessele
+# Copyright (c) 2016, Max Zwiessele, Alan Saul
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -47,3 +47,52 @@ class TestDebug(unittest.TestCase):
         
         array = np.random.normal(0, 1, (25,25))
         self.assertTrue(checkFullRank(tdot(array)))
+    
+    def test_fixed_inputs_median(self):
+        """ test fixed_inputs convenience function """
+        from GPy.plotting.matplot_dep.util import fixed_inputs
+        import GPy
+        X = np.random.randn(10, 3)
+        Y = np.sin(X) + np.random.randn(10, 3)*1e-3
+        m = GPy.models.GPRegression(X, Y)
+        fixed = fixed_inputs(m, [1], fix_routine='median', as_list=True, X_all=False)
+        self.assertTrue((0, np.median(X[:,0])) in fixed)
+        self.assertTrue((2, np.median(X[:,2])) in fixed)
+        self.assertTrue(len([t for t in fixed if t[0] == 1]) == 0) # Unfixed input should not be in fixed
+
+    def test_fixed_inputs_mean(self):
+        from GPy.plotting.matplot_dep.util import fixed_inputs
+        import GPy
+        X = np.random.randn(10, 3)
+        Y = np.sin(X) + np.random.randn(10, 3)*1e-3
+        m = GPy.models.GPRegression(X, Y)
+        fixed = fixed_inputs(m, [1], fix_routine='mean', as_list=True, X_all=False)
+        self.assertTrue((0, np.mean(X[:,0])) in fixed)
+        self.assertTrue((2, np.mean(X[:,2])) in fixed)
+        self.assertTrue(len([t for t in fixed if t[0] == 1]) == 0) # Unfixed input should not be in fixed
+
+    def test_fixed_inputs_zero(self):
+        from GPy.plotting.matplot_dep.util import fixed_inputs
+        import GPy
+        X = np.random.randn(10, 3)
+        Y = np.sin(X) + np.random.randn(10, 3)*1e-3
+        m = GPy.models.GPRegression(X, Y)
+        fixed = fixed_inputs(m, [1], fix_routine='zero', as_list=True, X_all=False)
+        self.assertTrue((0, 0.0) in fixed)
+        self.assertTrue((2, 0.0) in fixed)
+        self.assertTrue(len([t for t in fixed if t[0] == 1]) == 0) # Unfixed input should not be in fixed
+
+    def test_fixed_inputs_uncertain(self):
+        from GPy.plotting.matplot_dep.util import fixed_inputs
+        import GPy
+        from GPy.core.parameterization.variational import NormalPosterior
+        X_mu = np.random.randn(10, 3)
+        X_var = np.random.randn(10, 3)
+        X = NormalPosterior(X_mu, X_var)
+        Y = np.sin(X_mu) + np.random.randn(10, 3)*1e-3
+        m = GPy.models.BayesianGPLVM(Y, X=X_mu, X_variance=X_var, input_dim=3)
+        fixed = fixed_inputs(m, [1], fix_routine='median', as_list=True, X_all=False)
+        self.assertTrue((0, np.median(X.mean.values[:,0])) in fixed)
+        self.assertTrue((2, np.median(X.mean.values[:,2])) in fixed)
+        self.assertTrue(len([t for t in fixed if t[0] == 1]) == 0) # Unfixed input should not be in fixed
+


### PR DESCRIPTION
Added a convenience function for calculating an array suitable for passing to "fixed_inputs" when making predictions. Fixed inputs can be chosen to be computed to be the mean, median, or zeros.

Also Andreas mentioned he was having trouble with the BGPLVM prediction with uncertain inputs. Although this appears to be working correctly, we didn't have a test for the moment matching. Added a test for a linear kernel, in this case the output is still Gaussian, so the moment matching should discover the correct moments, and predictions should be close to those being projected.
