### PR TITLE
suppress UnicodeDecodeError: ascii codec - when import GPy

### DIFF
--- a/GPy/util/datasets.py
+++ b/GPy/util/datasets.py
@@ -54,12 +54,12 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True' #Checks if RTD is scannin
 
 if not (on_rtd):
     path = os.path.join(os.path.dirname(__file__), 'data_resources.json')
-    json_data=open(path).read()
+    json_data=open(path, encoding='utf-8').read()
     data_resources = json.loads(json_data)
 
 if not (on_rtd):
     path = os.path.join(os.path.dirname(__file__), 'football_teams.json')
-    json_data=open(path).read()
+    json_data=open(path, encoding='utf-8').read()
     football_dict = json.loads(json_data)
 
 
@@ -1482,5 +1482,3 @@ def cmu_mocap(subject, train_motions, test_motions=[], sample_every=4, data_set=
     if sample_every != 1:
         info += ' Data is sub-sampled to every ' + str(sample_every) + ' frames.'
     return data_details_return({'Y': Y, 'lbls' : lbls, 'Ytest': Ytest, 'lblstest' : lblstest, 'info': info, 'skel': skel}, data_set)
-
-


### PR DESCRIPTION
#319 : Cannot import GPy on mybinder with Python 3.5

The change is to give 'utf-8' encoding option of the function in `detasets.py`
My environment is on console and JupyterNotebook with Python 3.5.
