### PR TITLE
Automated Windows builds using Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,10 +34,7 @@ test_script:
 
 after_test:
   # This step builds your wheels.
-  # Again, you only need build.cmd if you're building C extensions for
-  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
-  # interpreter
-  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+  - "python setup.py bdist_wheel"
 
 artifacts:
   # bdist_wheel puts your built wheel in the dist directory

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
 
+branches:
+  only:
+    - deploy
+
 install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,24 @@
 environment:
 
   matrix:
-
-    # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
-    # The list here is complete (excluding Python 2.6, which
-    # isn't covered by this document) at the time of writing.
-
-    - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python35-x64"
+    - PYTHON_VERSION: 2.7
+      MINICONDA: C:\Miniconda
 
 branches:
   only:
     - deploy
 
-install:
+install: 
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "conda create -q -n build-environment python=%PYTHON_VERSION% numpy scipy matplotlib"
+  - activate build-environment
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
-  - "%PYTHON%\\python.exe -m pip install scipy"
+  # GPy needs paramz
   - "%PYTHON%\\python.exe -m pip install paramz"
-  - "%PYTHON%\\python.exe -m pip install matplotlib"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    # The list here is complete (excluding Python 2.6, which
+    # isn't covered by this document) at the time of writing.
+
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python35-x64"
+
+install:
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install wheel"
+  - "%PYTHON%\\python.exe -m pip install scipy"
+  - "%PYTHON%\\python.exe -m pip install paramz"
+  - "%PYTHON%\\python.exe -m pip install matplotlib"
+
+build: off
+
+test_script:
+  # Put your test command here.
+  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+  # you can remove "build.cmd" from the front of the command, as it's
+  # only needed to support those cases.
+  # Note that you must use the environment variable %PYTHON% to refer to
+  # the interpreter you're using - Appveyor does not do anything special
+  # to put the Python evrsion you want to use on PATH.
+  #- "build.cmd %PYTHON%\\python.exe setup.py test"
+
+after_test:
+  # This step builds your wheels.
+  # Again, you only need build.cmd if you're building C extensions for
+  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+  # interpreter
+  - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  # bdist_wheel puts your built wheel in the dist directory
+  - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ install:
   - "conda create -q -n build-environment python=%PYTHON_VERSION% numpy scipy matplotlib"
   - activate build-environment
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install wheel"
+  - python -m pip install wheel"
   # GPy needs paramz
-  - "%PYTHON%\\python.exe -m pip install paramz"
+  - python -m pip install paramz"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,17 @@ environment:
 
   matrix:
     - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda
+      MINICONDA: C:\Miniconda-x64
+    - PYTHON_VERSION: 3.5
+      MINICONDA: C:\Miniconda35-x64
+
+
 
 branches:
   only:
     - deploy
 
-install: 
+install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda


### PR DESCRIPTION
Doesn't yet automatically upload to Pypi but this does 90% of the required work.
Currently covers:
- Python 2.7, Windows 64bit
- Python 3.5, Windows 64bit
