### PR TITLE
Changes in EP/EPDTC to fix numerical issues

### DIFF
--- a/GPy/inference/latent_function_inference/var_dtc.py
+++ b/GPy/inference/latent_function_inference/var_dtc.py
@@ -88,6 +88,10 @@ class VarDTC(LatentFunctionInference):
             Kmm = kern.K(Z).copy()
             diag.add(Kmm, self.const_jitter)
             Lm = jitchol(Kmm)
+        else:
+            Kmm = tdot(Lm)
+            symmetrify(Kmm)
+
 
         # The rather complex computations of A, and the psi stats
         if uncertain_inputs:

--- a/GPy/testing/inference_tests.py
+++ b/GPy/testing/inference_tests.py
@@ -49,6 +49,43 @@ class InferenceXTestCase(unittest.TestCase):
         m.optimize()
         x, mi = m.infer_newX(m.Y, optimize=True)
         np.testing.assert_array_almost_equal(m.X, mi.X, decimal=2)
+class InferenceGPEP(unittest.TestCase):
+
+    def genData(self):
+        np.random.seed(1)
+        k = GPy.kern.RBF(1, variance=7., lengthscale=0.2)
+        X = np.random.rand(200,1)
+        f = np.random.multivariate_normal(np.zeros(200), k.K(X) + 1e-5 * np.eye(X.shape[0]))
+        lik = GPy.likelihoods.Bernoulli()
+        p = lik.gp_link.transf(f) # squash the latent function
+        Y = lik.samples(f).reshape(-1,1)
+        return X, Y
+
+    def test_inference_EP(self):
+        from paramz import ObsAr
+        X, Y = self.genData()
+        lik = GPy.likelihoods.Bernoulli()
+        k = GPy.kern.RBF(1, variance=7., lengthscale=0.2)
+        inf = GPy.inference.latent_function_inference.expectation_propagation.EP(max_iters=30, delta=0.5)
+        self.model = GPy.core.GP(X=X,
+                        Y=Y,
+                        kernel=k,
+                        inference_method=inf,
+                        likelihood=lik)
+        K = self.model.kern.K(X)
+        mu, Sigma, mu_tilde, tau_tilde, log_Z_tilde = self.model.inference_method.expectation_propagation(K, ObsAr(Y), lik, None)
+
+        v_tilde = mu_tilde * tau_tilde
+        p, m, d = self.model.inference_method._inference(K, tau_tilde, v_tilde, lik, Y_metadata=None,  Z_tilde=log_Z_tilde.sum())
+        p0, m0, d0 = super(GPy.inference.latent_function_inference.expectation_propagation.EP, inf).inference(k, X,lik ,mu_tilde[:,None], mean_function=None, variance=1./tau_tilde, K=K, Z_tilde=log_Z_tilde.sum() + np.sum(- 0.5*np.log(tau_tilde) + 0.5*(v_tilde*v_tilde*1./tau_tilde)))
+
+        assert (np.sum(np.array([m - m0,
+                    np.sum(d['dL_dK'] - d0['dL_dK']),
+                    np.sum(d['dL_dthetaL'] - d0['dL_dthetaL']),
+                    np.sum(d['dL_dm'] - d0['dL_dm']),
+                    np.sum(p._woodbury_vector - p0._woodbury_vector),
+                    np.sum(p.woodbury_inv - p0.woodbury_inv)])) < 1e6)
+
 
 class HMCSamplerTest(unittest.TestCase):
 
@@ -64,7 +101,7 @@ class HMCSamplerTest(unittest.TestCase):
 
         hmc = GPy.inference.mcmc.HMC(m,stepsize=1e-2)
         s = hmc.sample(num_samples=3)
-        
+
 class MCMCSamplerTest(unittest.TestCase):
 
     def test_sampling(self):

--- a/GPy/testing/util_tests.py
+++ b/GPy/testing/util_tests.py
@@ -1,21 +1,21 @@
 #===============================================================================
 # Copyright (c) 2016, Max Zwiessele, Alan Saul
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # * Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the following disclaimer in the documentation
 #   and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of GPy.testing.util_tests nor the names of its
 #   contributors may be used to endorse or promote products derived from
 #   this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -36,7 +36,7 @@ class TestDebug(unittest.TestCase):
         from GPy.util.debug import checkFinite
         array = np.random.normal(0, 1, 100).reshape(25,4)
         self.assertTrue(checkFinite(array, name='test'))
-        
+
         array[np.random.binomial(1, .3, array.shape).astype(bool)] = np.nan
         self.assertFalse(checkFinite(array))
 
@@ -45,10 +45,10 @@ class TestDebug(unittest.TestCase):
         from GPy.util.linalg import tdot
         array = np.random.normal(0, 1, 100).reshape(25,4)
         self.assertFalse(checkFullRank(tdot(array), name='test'))
-        
+
         array = np.random.normal(0, 1, (25,25))
         self.assertTrue(checkFullRank(tdot(array)))
-    
+
     def test_fixed_inputs_median(self):
         """ test fixed_inputs convenience function """
         from GPy.plotting.matplot_dep.util import fixed_inputs
@@ -113,8 +113,8 @@ class TestDebug(unittest.TestCase):
         #test data set. Not using random noise just in case it occasionally
         #causes it not to cluster correctly.
         #groundtruth cluster identifiers are: [0,1,1,0]
-        
-        #data contains a list of the four sets of time series (3 per data point)      
+
+        #data contains a list of the four sets of time series (3 per data point)
 
         data = [np.array([[ 2.18094245,  1.96529789,  2.00265523,  2.18218742,  2.06795428],
                 [ 1.62254829,  1.75748448,  1.83879347,  1.87531326,  1.52503496],
@@ -130,7 +130,7 @@ class TestDebug(unittest.TestCase):
                 [ 1.69336013,  1.72285186,  1.6339506 ,  1.61212022,  1.39198698]])]
 
         #inputs contains their associated X values
-        
+
         inputs = [np.array([[ 0.        ],
                 [ 0.68040097],
                 [ 1.20316795],
@@ -148,10 +148,66 @@ class TestDebug(unittest.TestCase):
                 [ 1.71881079],
                 [ 2.67162871],
                 [ 3.23761907]])]
-                    
+
         #try doing the clustering
         active = GPy.util.cluster_with_offset.cluster(data,inputs)
         #check to see that the clustering has correctly clustered the time series.
         clusters = set([frozenset(cluster) for cluster in active])
         assert set([1,2]) in clusters, "Offset Clustering algorithm failed"
         assert set([0,3]) in clusters, "Offset Clustering algoirthm failed"
+
+
+class TestUnivariateGaussian(unittest.TestCase):
+    def setUp(self):
+        self.zz = [-5.0, -0.8, 0.0, 0.5, 2.0, 10.0]
+
+    def test_logPdfNormal(self):
+        from GPy.util.univariate_Gaussian import logPdfNormal
+        pySols = [-13.4189385332,
+            -1.2389385332,
+            -0.918938533205,
+            -1.0439385332,
+            -2.9189385332,
+            -50.9189385332]
+        diff = 0.0
+        for i in range(len(pySols)):
+            diff += abs(logPdfNormal(self.zz[i]) - pySols[i])
+        self.assertTrue(diff  < 1e-10)
+
+    def test_cdfNormal(self):
+        from GPy.util.univariate_Gaussian import cdfNormal
+        pySols = [2.86651571879e-07,
+          0.211855398583,
+          0.5,
+          0.691462461274,
+          0.977249868052,
+          1.0]
+        diff = 0.0
+        for i in range(len(pySols)):
+            diff += abs(cdfNormal(self.zz[i]) - pySols[i])
+        self.assertTrue(diff  < 1e-10)
+
+    def test_logCdfNormal(self):
+        from GPy.util.univariate_Gaussian import logCdfNormal
+        pySols = [-15.064998394,
+          -1.55185131919,
+          -0.69314718056,
+          -0.368946415289,
+          -0.023012909329,
+          0.0]
+        diff = 0.0
+        for i in range(len(pySols)):
+            diff += abs(logCdfNormal(self.zz[i]) - pySols[i])
+        self.assertTrue(diff  < 1e-10)
+    def test_derivLogCdfNormal(self):
+        from GPy.util.univariate_Gaussian import derivLogCdfNormal
+        pySols = [5.18650396941,
+          1.3674022693,
+          0.79788456081,
+          0.50916043387,
+          0.0552478626962,
+          0.0]
+        diff = 0.0
+        for i in range(len(pySols)):
+          diff += abs(derivLogCdfNormal(self.zz[i]) - pySols[i])
+        self.assertTrue(diff  < 1e-8)

--- a/GPy/util/univariate_Gaussian.py
+++ b/GPy/util/univariate_Gaussian.py
@@ -23,3 +23,164 @@ def inv_std_norm_cdf(x):
     inv_erf = np.sign(z) * np.sqrt( np.sqrt(b**2 - ln1z2/a) - b )
     return np.sqrt(2) * inv_erf
 
+def logPdfNormal(z):
+    """
+    Robust implementations of log pdf of a standard normal.
+
+     @see [[https://github.com/mseeger/apbsint/blob/master/src/eptools/potentials/SpecfunServices.h original implementation]]
+     in C from Matthias Seeger.
+    """
+    return -0.5 * (M_LN2PI + z * z)
+
+def cdfNormal(z):
+    """
+    Robust implementations of cdf of a standard normal.
+
+     @see [[https://github.com/mseeger/apbsint/blob/master/src/eptools/potentials/SpecfunServices.h original implementation]]
+     in C from Matthias Seeger.
+    */
+    """
+    if (abs(z) < ERF_CODY_LIMIT1):
+        # Phi(z) approx (1+y R_3(y^2))/2, y=z/sqrt(2)
+        return 0.5 * (1.0 + (z / M_SQRT2) * _erfRationalHelperR3(0.5 * z * z))
+    elif (z < 0.0):
+        # Phi(z) approx N(z)Q(-z)/(-z), z<0
+        return np.exp(logPdfNormal(z)) * _erfRationalHelper(-z) / (-z)
+    else:
+        return 1.0 - np.exp(logPdfNormal(z)) * _erfRationalHelper(z) / z
+
+
+
+def logCdfNormal(z):
+    """
+    Robust implementations of log cdf of a standard normal.
+
+     @see [[https://github.com/mseeger/apbsint/blob/master/src/eptools/potentials/SpecfunServices.h original implementation]]
+     in C from Matthias Seeger.
+    """
+    if (abs(z) < ERF_CODY_LIMIT1):
+        # Phi(z) approx  (1+y R_3(y^2))/2, y=z/sqrt(2)
+        return np.log1p((z / M_SQRT2) * _erfRationalHelperR3(0.5 * z * z)) - M_LN2
+    elif (z < 0.0):
+        # Phi(z) approx N(z)Q(-z)/(-z), z<0
+        return logPdfNormal(z) - np.log(-z) + np.log(_erfRationalHelper(-z))
+    else:
+        return np.log1p(-(np.exp(logPdfNormal(z))) * _erfRationalHelper(z) / z)
+
+
+
+def derivLogCdfNormal(z):
+    """
+     Robust implementations of derivative of the log cdf of a standard normal.
+
+     @see [[https://github.com/mseeger/apbsint/blob/master/src/eptools/potentials/SpecfunServices.h original implementation]]
+     in C from Matthias Seeger.
+    """
+    if (abs(z) < ERF_CODY_LIMIT1):
+        # Phi(z) approx (1 + y R_3(y^2))/2, y = z/sqrt(2)
+        return 2.0 * np.exp(logPdfNormal(z)) / (1.0 + (z / M_SQRT2) * _erfRationalHelperR3(0.5 * z * z))
+    elif (z < 0.0):
+        # Phi(z) approx N(z) Q(-z)/(-z), z<0
+        return -z / _erfRationalHelper(-z)
+    else:
+        t = np.exp(logPdfNormal(z))
+        return t / (1.0 - t * _erfRationalHelper(z) / z)
+
+
+def _erfRationalHelper(x):
+    assert x > 0.0, "Arg of erfRationalHelper should be >0.0; was {}".format(x)
+
+    if (x >= ERF_CODY_LIMIT2):
+        """
+         x/sqrt(2) >= 4
+
+         Q(x)   = 1 + sqrt(pi) y R_1(y),
+         R_1(y) = poly(p_j,y) / poly(q_j,y),  where  y = 2/(x*x)
+
+         Ordering of arrays: 4,3,2,1,0,5 (only for numerator p_j; q_5=1)
+         ATTENTION: The p_j are negative of the entries here
+         p (see P1_ERF)
+         q (see Q1_ERF)
+        """
+        y = 2.0 / (x * x)
+
+        res = y * P1_ERF[5]
+        den = y
+        i = 0
+
+        while (i <= 3):
+            res = (res + P1_ERF[i]) * y
+            den = (den + Q1_ERF[i]) * y
+            i += 1
+
+        # Minus, because p(j) values have to be negated
+        return 1.0 - M_SQRTPI * y * (res + P1_ERF[4]) / (den + Q1_ERF[4])
+    else:
+        """
+         x/sqrt(2) < 4, x/sqrt(2) >= 0.469
+
+         Q(x)   = sqrt(pi) y R_2(y),
+         R_2(y) = poly(p_j,y) / poly(q_j,y),   y = x/sqrt(2)
+
+         Ordering of arrays: 7,6,5,4,3,2,1,0,8 (only p_8; q_8=1)
+         p (see P2_ERF)
+         q (see Q2_ERF
+        """
+        y = x / M_SQRT2
+        res = y * P2_ERF[8]
+        den = y
+        i = 0
+
+        while (i <= 6):
+            res = (res + P2_ERF[i]) * y
+            den = (den + Q2_ERF[i]) * y
+            i += 1
+
+        return M_SQRTPI * y * (res + P2_ERF[7]) / (den + Q2_ERF[7])
+
+def _erfRationalHelperR3(y):
+    assert y >= 0.0, "Arg of erfRationalHelperR3 should be >=0.0; was {}".format(y)
+
+    nom = y * P3_ERF[4]
+    den = y
+    i = 0
+    while (i <= 2):
+        nom = (nom + P3_ERF[i]) * y
+        den = (den + Q3_ERF[i]) * y
+        i += 1
+    return (nom + P3_ERF[3]) / (den + Q3_ERF[3])
+
+ERF_CODY_LIMIT1 = 0.6629
+ERF_CODY_LIMIT2 = 5.6569
+M_LN2PI         = 1.83787706640934533908193770913
+M_LN2           = 0.69314718055994530941723212146
+M_SQRTPI        = 1.77245385090551602729816748334
+M_SQRT2         = 1.41421356237309504880168872421
+
+#weights for the erfHelpers (defined here to avoid redefinitions at every call)
+P1_ERF = [
+3.05326634961232344e-1, 3.60344899949804439e-1,
+1.25781726111229246e-1, 1.60837851487422766e-2,
+6.58749161529837803e-4, 1.63153871373020978e-2]
+Q1_ERF = [
+2.56852019228982242e+0, 1.87295284992346047e+0,
+5.27905102951428412e-1, 6.05183413124413191e-2,
+2.33520497626869185e-3]
+P2_ERF = [
+5.64188496988670089e-1, 8.88314979438837594e+0,
+6.61191906371416295e+1, 2.98635138197400131e+2,
+8.81952221241769090e+2, 1.71204761263407058e+3,
+2.05107837782607147e+3, 1.23033935479799725e+3,
+2.15311535474403846e-8]
+Q2_ERF = [
+1.57449261107098347e+1, 1.17693950891312499e+2,
+5.37181101862009858e+2, 1.62138957456669019e+3,
+3.29079923573345963e+3, 4.36261909014324716e+3,
+3.43936767414372164e+3, 1.23033935480374942e+3]
+P3_ERF = [
+3.16112374387056560e+0, 1.13864154151050156e+2,
+3.77485237685302021e+2, 3.20937758913846947e+3,
+1.85777706184603153e-1]
+Q3_ERF = [
+2.36012909523441209e+1, 2.44024637934444173e+2,
+1.28261652607737228e+3, 2.84423683343917062e+3]


### PR DESCRIPTION
Changes in EP/EPDTC to fix numerical issues and increase the flexibility of the inference

    Changes to avoid numerical issues and improve the performance:
    - Keep value of the EP parameters between calls
    - Enforce positivity of tau_tilde
    - Stable computation of the EP moments for the Bernoulli likelihood
    - Compute marginal in the GP model without directly inverting tau_tilde

    Changes to improve the flexibility:
    - Add parameter for maximum number of iterations
    - Distinguish between alternated/nested mode
    - Distinguish between sequential/parallel updates in EP