### PR TITLE
fix: slight modification to MLP mapping to reduce potential for numpy…

### DIFF
--- a/GPy/mappings/mlp.py
+++ b/GPy/mappings/mlp.py
@@ -35,7 +35,7 @@ class MLP(Mapping):
 
         # Backpropagation to hidden layer.
         dL_dact = np.dot(dL_dF, self.W2.T)
-        dL_dlayer1 = dL_dact * (1 - np.power(activations, 2))
+        dL_dlayer1 = dL_dact * (1 - np.square(activations))
 
         # Finally, evaluate the first-layer gradients.
         self.W1.gradient = np.dot(X.T,dL_dlayer1)
@@ -47,7 +47,7 @@ class MLP(Mapping):
 
         # Backpropagation to hidden layer.
         dL_dact = np.dot(dL_dF, self.W2.T)
-        dL_dlayer1 = dL_dact * (1 - np.power(activations, 2))
+        dL_dlayer1 = dL_dact * (1 - np.square(activations))
 
         return np.dot(dL_dlayer1, self.W1.T)
 

--- a/GPy/mappings/mlp.py
+++ b/GPy/mappings/mlp.py
@@ -35,7 +35,7 @@ class MLP(Mapping):
 
         # Backpropagation to hidden layer.
         dL_dact = np.dot(dL_dF, self.W2.T)
-        dL_dlayer1 = dL_dact / np.square(np.cosh(layer1))
+        dL_dlayer1 = dL_dact * (1 - np.power(activations, 2))
 
         # Finally, evaluate the first-layer gradients.
         self.W1.gradient = np.dot(X.T,dL_dlayer1)
@@ -47,7 +47,7 @@ class MLP(Mapping):
 
         # Backpropagation to hidden layer.
         dL_dact = np.dot(dL_dF, self.W2.T)
-        dL_dlayer1 = dL_dact / np.square(np.cosh(layer1))
+        dL_dlayer1 = dL_dact * (1 - np.power(activations, 2))
 
         return np.dot(dL_dlayer1, self.W1.T)
 


### PR DESCRIPTION
… overflows and unnecessary computation. np.square(np.cosh(layer1)) was causing a numpy overflow error for some inputs. Since we have already computed the activations earlier in these functions, we can just make use of them directly instead of evaluating cosh() on the out output for the first layer (layer1). This modification eliminated the overflow for my data and passed all relevant tests.