### PR TITLE
Add mean function functionality to dtc inference method

### DIFF
--- a/GPy/core/sparse_gp_mpi.py
+++ b/GPy/core/sparse_gp_mpi.py
@@ -34,7 +34,9 @@ class SparseGP_MPI(SparseGP):
 
     """
 
-    def __init__(self, X, Y, Z, kernel, likelihood, variational_prior=None, inference_method=None, name='sparse gp', Y_metadata=None, mpi_comm=None, normalizer=False):
+    def __init__(self, X, Y, Z, kernel, likelihood, variational_prior=None,
+                 mean_function=None, inference_method=None, name='sparse gp',
+                 Y_metadata=None, mpi_comm=None, normalizer=False):
         self._IN_OPTIMIZATION_ = False
         if mpi_comm != None:
             if inference_method is None:
@@ -42,12 +44,12 @@ class SparseGP_MPI(SparseGP):
             else:
                 assert isinstance(inference_method, VarDTC_minibatch), 'inference_method has to support MPI!'
 
-        super(SparseGP_MPI, self).__init__(X, Y, Z, kernel, likelihood, inference_method=inference_method, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
+        super(SparseGP_MPI, self).__init__(X, Y, Z, kernel, likelihood, inference_method=inference_method, mean_function=mean_function, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
         self.update_model(False)
-        
+
         if variational_prior is not None:
             self.link_parameter(variational_prior)
-            
+
         self.mpi_comm = mpi_comm
         # Manage the data (Y) division
         if mpi_comm != None:
@@ -118,4 +120,3 @@ class SparseGP_MPI(SparseGP):
             update_gradients(self, mpi_comm=self.mpi_comm)
         else:
             super(SparseGP_MPI,self).parameters_changed()
-

--- a/GPy/models/sparse_gp_regression.py
+++ b/GPy/models/sparse_gp_regression.py
@@ -30,7 +30,7 @@ class SparseGPRegression(SparseGP_MPI):
 
     """
 
-    def __init__(self, X, Y, kernel=None, Z=None, num_inducing=10, X_variance=None, normalizer=None, mpi_comm=None, name='sparse_gp'):
+    def __init__(self, X, Y, kernel=None, Z=None, num_inducing=10, X_variance=None, mean_function=None, normalizer=None, mpi_comm=None, name='sparse_gp'):
         num_data, input_dim = X.shape
 
         # kern defaults to rbf (plus white for stability)
@@ -55,7 +55,8 @@ class SparseGPRegression(SparseGP_MPI):
         else:
             infr = VarDTC()
 
-        SparseGP_MPI.__init__(self, X, Y, Z, kernel, likelihood, inference_method=infr, normalizer=normalizer, mpi_comm=mpi_comm, name=name)
+        SparseGP_MPI.__init__(self, X, Y, Z, kernel, likelihood, mean_function=mean_function,
+        inference_method=infr, normalizer=normalizer, mpi_comm=mpi_comm, name=name)
 
     def parameters_changed(self):
         from ..inference.latent_function_inference.var_dtc_parallel import update_gradients_sparsegp,VarDTC_minibatch

--- a/GPy/testing/inference_tests.py
+++ b/GPy/testing/inference_tests.py
@@ -49,6 +49,7 @@ class InferenceXTestCase(unittest.TestCase):
         m.optimize()
         x, mi = m.infer_newX(m.Y, optimize=True)
         np.testing.assert_array_almost_equal(m.X, mi.X, decimal=2)
+
 class InferenceGPEP(unittest.TestCase):
 
     def genData(self):
@@ -131,6 +132,16 @@ class InferenceGPEP(unittest.TestCase):
                     np.sum(d['dL_dm'] - d0['dL_dm']),
                     np.sum(p._woodbury_vector - p0._woodbury_vector),
                     np.sum(p.woodbury_inv - p0.woodbury_inv)])) < 1e6)
+
+class VarDtcTest(unittest.TestCase):
+
+    def test_var_dtc_inference_with_mean(self):
+        """ Check dL_dm in var_dtc is calculated correctly"""
+        np.random.seed(1)
+        x = np.linspace(0.,2*np.pi,100)[:,None]
+        y = -np.cos(x)+np.random.randn(*x.shape)*0.3+1
+        m = GPy.models.SparseGPRegression(x,y, mean_function=GPy.mappings.Linear(input_dim=1, output_dim=1))
+        self.assertTrue(m.checkgrad())
 
 
 class HMCSamplerTest(unittest.TestCase):


### PR DESCRIPTION
Allows us to use mean functions with sparse GP regression. The changes are mainly adding mean_function as an input to required methods and then a small reordering of the maths to get dL_dm out.