### PR TITLE
Allow setup.py to be parsed without numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ from __future__ import print_function
 import os
 import sys
 from setuptools import setup, Extension
-import numpy as np
 import codecs
 
 def read(fname):
@@ -80,32 +79,39 @@ else:
     compile_flags = [ '-fopenmp', '-O3']
     link_args = ['-lgomp' ]
 
-ext_mods = [Extension(name='GPy.kern.src.stationary_cython',
-                      sources=['GPy/kern/src/stationary_cython.c',
-                               'GPy/kern/src/stationary_utils.c'],
-                      include_dirs=[np.get_include(),'.'],
-                      extra_compile_args=compile_flags,
-                      extra_link_args = link_args),
-            Extension(name='GPy.util.choleskies_cython',
-                      sources=['GPy/util/choleskies_cython.c'],
-                      include_dirs=[np.get_include(),'.'],
-                      extra_link_args = link_args,
-                      extra_compile_args=compile_flags),
-            Extension(name='GPy.util.linalg_cython',
-                      sources=['GPy/util/linalg_cython.c'],
-                      include_dirs=[np.get_include(),'.'],
-                      extra_compile_args=compile_flags,
-                      extra_link_args = link_args),
-            Extension(name='GPy.kern.src.coregionalize_cython',
-                      sources=['GPy/kern/src/coregionalize_cython.c'],
-                      include_dirs=[np.get_include(),'.'],
-                      extra_compile_args=compile_flags,
-                      extra_link_args = link_args),
-            Extension(name='GPy.models.state_space_cython',
-                      sources=['GPy/models/state_space_cython.c'],
-                      include_dirs=[np.get_include(),'.'],
-                      extra_compile_args=compile_flags,
-                      extra_link_args = link_args)]
+try:
+    # So that we don't need numpy installed to determine it's a dependency.
+    import numpy as np
+
+    ext_mods = [Extension(name='GPy.kern.src.stationary_cython',
+                          sources=['GPy/kern/src/stationary_cython.c',
+                                   'GPy/kern/src/stationary_utils.c'],
+                          include_dirs=[np.get_include(), '.'],
+                          extra_compile_args=compile_flags,
+                          extra_link_args=link_args),
+                Extension(name='GPy.util.choleskies_cython',
+                          sources=['GPy/util/choleskies_cython.c'],
+                          include_dirs=[np.get_include(), '.'],
+                          extra_link_args=link_args,
+                          extra_compile_args=compile_flags),
+                Extension(name='GPy.util.linalg_cython',
+                          sources=['GPy/util/linalg_cython.c'],
+                          include_dirs=[np.get_include(), '.'],
+                          extra_compile_args=compile_flags,
+                          extra_link_args=link_args),
+                Extension(name='GPy.kern.src.coregionalize_cython',
+                          sources=['GPy/kern/src/coregionalize_cython.c'],
+                          include_dirs=[np.get_include(), '.'],
+                          extra_compile_args=compile_flags,
+                          extra_link_args=link_args),
+                Extension(name='GPy.models.state_space_cython',
+                          sources=['GPy/models/state_space_cython.c'],
+                          include_dirs=[np.get_include(), '.'],
+                          extra_compile_args=compile_flags,
+                          extra_link_args=link_args)]
+except ModuleNotFoundError:
+    ext_mods = []
+
 
 setup(name = 'GPy',
       version = __version__,


### PR DESCRIPTION
If numpy isn't available, don't define ext_mods, pip will then determine numpy is required, install it, then call us again.

Fixes #653