### PR TITLE
Fix Cython compilation errors

### DIFF
--- a/GPy/models/state_space_cython.pyx
+++ b/GPy/models/state_space_cython.pyx
@@ -484,7 +484,7 @@ cdef class AQcompute_batch_Cython(Q_handling_Cython):
             if matrix_index in self.Q_square_root_dict:
                 square_root = self.Q_square_root_dict[matrix_index]
             else:
-                if matrix_index not in self.Q_svd_dict
+                if matrix_index not in self.Q_svd_dict:
                     U,S,Vh = sp.linalg.svd( self.Qs[:,:, matrix_index], 
                                         full_matrices=False, compute_uv=True, 
                                         overwrite_a=False, check_finite=False)
@@ -514,7 +514,7 @@ cdef class AQcompute_batch_Cython(Q_handling_Cython):
             if matrix_index in self.Q_inverse_dict:
                 Q_inverse = self.Q_inverse_dict[matrix_index]
             else:
-                if matrix_index not in self.Q_svd_dict
+                if matrix_index not in self.Q_svd_dict:
                     U,S,Vh = sp.linalg.svd( self.Qs[:,:, matrix_index], 
                                         full_matrices=False, compute_uv=True, 
                                         overwrite_a=False, check_finite=False)
@@ -522,7 +522,7 @@ cdef class AQcompute_batch_Cython(Q_handling_Cython):
                 else:
                     U,S,Vh = self.Q_svd_dict[matrix_index]
                        
-               Q_inverse = Q_inverse = np.dot( Vh.T * ( 1.0/(S + jitter)) , U.T )
+                Q_inverse = Q_inverse = np.dot( Vh.T * ( 1.0/(S + jitter)) , U.T )
                 self.Q_inverse_dict[matrix_index] = Q_inverse
             
             return Q_inverse


### PR DESCRIPTION
Fixes the following kind of errors using Cython-0.28.5:
```
Error compiling Cython file:
------------------------------------------------------------
...


            if matrix_index in self.Q_square_root_dict:
                square_root = self.Q_square_root_dict[matrix_index]
            else:
                if matrix_index not in self.Q_svd_dict
                                                     ^
------------------------------------------------------------

models\state_space_cython.pyx:487:54: Expected ':', found 'NEWLINE'
```

```
Error compiling Cython file:
------------------------------------------------------------
...
                                        overwrite_a=False, check_finite=False)
                    self.Q_svd_dict[matrix_index] = (U,S,Vh)
                else:
                    U,S,Vh = self.Q_svd_dict[matrix_index]

               Q_inverse = Q_inverse = np.dot( Vh.T * ( 1.0/(S + jitter)) , U.T )
^
------------------------------------------------------------

models\state_space_cython.pyx:525:0: Inconsistent indentation
```