### PR TITLE
Fix compilation errors in state_space_cython.pyx 

### DIFF
--- a/GPy/models/state_space_cython.pyx
+++ b/GPy/models/state_space_cython.pyx
@@ -484,7 +484,7 @@ cdef class AQcompute_batch_Cython(Q_handling_Cython):
             if matrix_index in self.Q_square_root_dict:
                 square_root = self.Q_square_root_dict[matrix_index]
             else:
-                if matrix_index not in self.Q_svd_dict
+                if matrix_index not in self.Q_svd_dict:
                     U,S,Vh = sp.linalg.svd( self.Qs[:,:, matrix_index], 
                                         full_matrices=False, compute_uv=True, 
                                         overwrite_a=False, check_finite=False)
@@ -514,7 +514,7 @@ cdef class AQcompute_batch_Cython(Q_handling_Cython):
             if matrix_index in self.Q_inverse_dict:
                 Q_inverse = self.Q_inverse_dict[matrix_index]
             else:
-                if matrix_index not in self.Q_svd_dict
+                if matrix_index not in self.Q_svd_dict:
                     U,S,Vh = sp.linalg.svd( self.Qs[:,:, matrix_index], 
                                         full_matrices=False, compute_uv=True, 
                                         overwrite_a=False, check_finite=False)
@@ -522,7 +522,7 @@ cdef class AQcompute_batch_Cython(Q_handling_Cython):
                 else:
                     U,S,Vh = self.Q_svd_dict[matrix_index]
                        
-               Q_inverse = Q_inverse = np.dot( Vh.T * ( 1.0/(S + jitter)) , U.T )
+                Q_inverse = Q_inverse = np.dot( Vh.T * ( 1.0/(S + jitter)) , U.T )
                 self.Q_inverse_dict[matrix_index] = Q_inverse
             
             return Q_inverse


### PR DESCRIPTION
To get GPy to install on my Mac, I need to manually rebuild the cython extensions.  A fuller fix (obviously a hairy PR to put together as one needs to test it across multiple platforms) would delete the C files and fix the build to automatically generate them.

Never the less this smaller PR correct some syntax errors in the pyx file which prevented cython from running correctly.