### PR TITLE
Fix rank>0 thread exiting during SparseGP multiprocessing

### DIFF
--- a/GPy/core/sparse_gp_mpi.py
+++ b/GPy/core/sparse_gp_mpi.py
@@ -108,6 +108,7 @@ class SparseGP_MPI(SparseGP):
                             raise
                         self._fail_count += 1
                 elif flag==-1:
+                    ret = None
                     break
                 else:
                     self._IN_OPTIMIZATION_ = False


### PR DESCRIPTION
If you run `mpiexec -n 2` on any code to try to use MPI multiprocessing for SparseGPRegression, it crashes (see #618) because the rank>1 processes do not have `ret` defined.