### PR TITLE
Add error message for excess inducing points

### DIFF
--- a/GPy/models/gp_multiout_regression_md.py
+++ b/GPy/models/gp_multiout_regression_md.py
@@ -60,6 +60,10 @@ class GPMultioutRegressionMD(SparseGP):
             kernel = kern.RBF(X.shape[1])
         if kernel_row is None:
             kernel_row = kern.RBF(Xr_dim,name='kern_row')
+            
+        if num_inducing[1] > self.output_dim:
+            msg = 'Number of inducing points ({}) in latent space must be <= output dim ({})'
+            raise ValueError(msg.format(num_inducing[1], self.output_dim))
 
         if init=='GP':
             from . import SparseGPRegression, BayesianGPLVM


### PR DESCRIPTION
The number of inducing points in the latent space defaults to 10, which creates an error if there are fewer than 10 conditions (i.e. output dimension is less than 10). Currently this error shows up somewhat opaquely. This fix makes the error explicit, which may save time for future developers.

The current error shown is:

```
...
...
~/code/anaconda/lib/python3.6/site-packages/GPy/inference/latent_function_inference/vardtc_svi_multiout_miss.py in inference_d(self, d, beta, Y, indexD, grad_dict, mid_res, uncertain_inputs_r, uncertain_inputs_c, Mr, Mc)
     82         LcInvPsi1_cT = dtrtrs(Lc, psi1_c.T)[0]
     83         LrInvPsi1_rT = dtrtrs(Lr, psi1_r.T)[0]
---> 84 
     85         tr_LrInvPsi2_rLrInvT_LrInvSrLrInvT = (LrInvPsi2_rLrInvT*LrInvSrLrInvT).sum()
     86         tr_LcInvPsi2_cLcInvT_LcInvScLcInvT = (LcInvPsi2_cLcInvT*LcInvScLcInvT).sum()

ValueError: operands could not be broadcast together with shapes (5,5) (6,6) 
```