### PR TITLE
Fix clean install of Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,11 @@ import sys
 from setuptools import setup, Extension
 import codecs
 
+try:
+    ModuleNotFoundError
+except NameError:
+    ModuleNotFoundError = ImportError
+
 def read(fname):
     with codecs.open(fname, 'r', 'latin') as f:
         return f.read()


### PR DESCRIPTION
If using Python 2.7 and don't have numpy installed before hand this error will occur: `NameError: name 'ModuleNotFoundError' is not defined`. Need work around for this problem