### PR TITLE
Fix model.plot() to work with new Numpy update.

### DIFF
--- a/GPy/plotting/gpy_plot/plot_util.py
+++ b/GPy/plotting/gpy_plot/plot_util.py
@@ -118,7 +118,7 @@ def helper_for_plot_data(self, X, plot_limits, visible_dims, fixed_inputs, resol
         resolution = resolution or 200
         Xnew, xmin, xmax = x_frame1D(X[:,free_dims], plot_limits=plot_limits, resolution=resolution)
         Xgrid = np.zeros((Xnew.shape[0],self.input_dim))
-        Xgrid[:,free_dims] = Xnew
+        Xgrid[:,free_dims[0]] = Xnew.squeeze()
         for i,v in fixed_inputs:
             Xgrid[:,i] = v
         x = Xgrid


### PR DESCRIPTION
This fixes both the issues

https://github.com/SheffieldML/GPy/issues/723

and 

https://github.com/SheffieldML/GPy/issues/728

I am reasonably sure this doesn't break any backward compatibility with earlier Numpy versions. As per my previous comments in the first link:

> My reason for thinking this is probably ok, is that we are already inside an if block stating that len(free_dims) == 1. Furthermore, if Xnew cannot be squeezed to a 1D array then the original statement would have failed anyway.

> I think the issue must be in a Numpy update that has changed the rules for assignment.