### PR TITLE
Stop using legacy bdist_wininst

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ test_script:
 
 after_test:
   # This step builds your wheels.
-  - "python setup.py bdist_wheel bdist_wininst"
+  - "python setup.py bdist_wheel"
   - codecov
 
 artifacts:


### PR DESCRIPTION
The `bdist_wininst` file type is deprecated by PyPI:

* https://www.python.org/dev/peps/pep-0527/

It will probably be removed soon:

* https://github.com/pypa/warehouse/issues/6792
