### PR TITLE
fix: rearrange expression to avoid an n^2 array

### DIFF
--- a/GPy/inference/latent_function_inference/var_dtc.py
+++ b/GPy/inference/latent_function_inference/var_dtc.py
@@ -142,8 +142,7 @@ class VarDTC(LatentFunctionInference):
         Cpsi1Vf, _ = dtrtrs(Lm, tmp, lower=1, trans=1)
 
         # data fit and derivative of L w.r.t. Kmm
-        dL_dm = -np.dot((_LBi_Lmi_psi1.T.dot(_LBi_Lmi_psi1))
-                        - np.eye(Y.shape[0]), VVT_factor)
+        dL_dm = -_LBi_Lmi_psi1.T.dot(_LBi_Lmi_psi1.dot(VVT_factor)) + VVT_factor
 
         delit = tdot(_LBi_Lmi_psi1Vf)
         data_fit = np.trace(delit)


### PR DESCRIPTION
Fixes: #637
This rearranges the gradient evaluation to avoid creating an n<sup>2 </sup> array as an intermediate product when using SparseGPRegression.

dL_dm = - (L<sup>T </sup>L - I)V
becomes
dL_dm = - L<sup>T </sup> (LV) + V