### PR TITLE
Fix predictive_gradients and posterior_covariance_between_points when normalizer=True

### DIFF
--- a/GPy/testing/model_tests.py
+++ b/GPy/testing/model_tests.py
@@ -1168,7 +1168,7 @@ class GradientTests(np.testing.TestCase):
         Y = np.array([[1], [2]])
         m = GPy.models.GPRegression(X1, Y, kernel=k)
 
-        result = m.posterior_covariance_between_points(X1, X2)
+        result = m._raw_posterior_covariance_between_points(X1, X2)
         expected = np.array([[0.4, 2.2], [1.0, 1.0]]) / 3.0
 
         self.assertTrue(np.allclose(result, expected))
@@ -1179,7 +1179,7 @@ class GradientTests(np.testing.TestCase):
         m = _create_missing_data_model(k, Q)
 
         with self.assertRaises(RuntimeError):
-            m.posterior_covariance_between_points(np.array([[1], [2]]), np.array([[3], [4]]))
+            m._raw_posterior_covariance_between_points(np.array([[1], [2]]), np.array([[3], [4]]))
     
     def test_multioutput_model_with_derivative_observations(self):
         f = lambda x: np.sin(x)+0.1*(x-2.)**2-0.005*x**3
@@ -1241,6 +1241,45 @@ class GradientTests(np.testing.TestCase):
         m = GPy.models.MultioutputGP(X_list=[x, xd], Y_list=[y, yd], kernel_list=[se, se_der], likelihood_list = [gauss, probit], inference_method=GPy.inference.latent_function_inference.EP(ep_mode="nested"))
         
         self.assertTrue(m.checkgrad())       
+
+
+    def test_predictive_gradients_with_normalizer(self):
+        """
+        Check that model.predictive_gradients returns the gradients of
+        model.predict when normalizer=True 
+        """
+        N, M, Q = 10, 15, 3
+        X = np.random.rand(M,Q)
+        Y = np.random.rand(M,1)
+        x = np.random.rand(N, Q)
+        model = GPy.models.GPRegression(X=X, Y=Y, normalizer=True)
+        from GPy.models import GradientChecker
+        gm = GradientChecker(lambda x: model.predict(x)[0],
+                             lambda x: model.predictive_gradients(x)[0],
+                             x, 'x')
+        gc = GradientChecker(lambda x: model.predict(x)[1],
+                             lambda x: model.predictive_gradients(x)[1],
+                             x, 'x')
+        assert(gm.checkgrad())
+        assert(gc.checkgrad())
+
+
+    def test_posterior_covariance_between_points_with_normalizer(self):
+        """
+        Check that model.posterior_covariance_between_points returns 
+        the covariance from model.predict when normalizer=True
+        """
+        np.random.seed(3)
+        N, M, Q = 10, 15, 3
+        X = np.random.rand(M,Q)
+        Y = np.random.rand(M,1)
+        x = np.random.rand(2, Q)
+        model = GPy.models.GPRegression(X=X, Y=Y, normalizer=True)
+
+        c1 = model.posterior_covariance_between_points(x,x)
+        c2 = model.predict(x, full_cov=True)[1]
+        np.testing.assert_allclose(c1,c2)
+
 
 def _create_missing_data_model(kernel, Q):
     D1, D2, D3, N, num_inducing = 13, 5, 8, 400, 3


### PR DESCRIPTION
Addresses #802, with new tests added to `model_test.py`:

1. Add normalization in `model.predictive_gradients` so that it returns the gradients of `model.predict` even when `normalizer=True`.

2. Add normalization and likelihood in `model.posterior_covariance_between_points` so that it is consistent with the (co)variance from `model.predict` even when `normalizer=True`.

Fix 1 is important because `model.predictive_gradients` is used extensively in [GPyOpt](https://github.com/SheffieldML/GPyOpt) and [Emukit](https://github.com/amzn/emukit).  Fix 2 may be more controversial, although I suspect that most people expect `model.posterior_covariance_between_points(x,x)` to return the same result as `model.predict(x)[1]`.
