### PR TITLE
Use super().__init__ consistently

### DIFF
--- a/GPy/core/gp_grid.py
+++ b/GPy/core/gp_grid.py
@@ -46,7 +46,7 @@ class GpGrid(GP):
 
         inference_method = gaussian_grid_inference.GaussianGridInference()
 
-        GP.__init__(self, X, Y, kernel, likelihood, inference_method=inference_method, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
+        super(GpGrid, self).__init__(X, Y, kernel, likelihood, inference_method=inference_method, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
         self.posterior = None
 
     def parameters_changed(self):

--- a/GPy/core/sparse_gp.py
+++ b/GPy/core/sparse_gp.py
@@ -53,7 +53,7 @@ class SparseGP(GP):
         self.Z = Param('inducing inputs', Z)
         self.num_inducing = Z.shape[0]
 
-        GP.__init__(self, X, Y, kernel, likelihood, mean_function, inference_method=inference_method, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
+        super(SparseGP, self).__init__(X, Y, kernel, likelihood, mean_function, inference_method=inference_method, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
 
         logger.info("Adding Z as parameter")
         self.link_parameter(self.Z, index=0)

--- a/GPy/mappings/compound.py
+++ b/GPy/mappings/compound.py
@@ -21,7 +21,7 @@ class Compound(Mapping):
     def __init__(self, mapping1, mapping2):
         assert(mapping1.output_dim==mapping2.input_dim)
         input_dim, output_dim = mapping1.input_dim, mapping2.output_dim
-        Mapping.__init__(self, input_dim=input_dim, output_dim=output_dim)
+        super(Compound, self).__init__(input_dim=input_dim, output_dim=output_dim)
         self.mapping1 = mapping1
         self.mapping2 = mapping2
         self.link_parameters(self.mapping1, self.mapping2)

--- a/GPy/mappings/constant.py
+++ b/GPy/mappings/constant.py
@@ -21,7 +21,7 @@ class Constant(Mapping):
     """
 
     def __init__(self, input_dim, output_dim, value=0., name='constmap'):
-        Mapping.__init__(self, input_dim=input_dim, output_dim=output_dim, name=name)
+        super(Constant, self).__init__(input_dim=input_dim, output_dim=output_dim, name=name)
         value = np.atleast_1d(value)
         if not len(value.shape) ==1:
             raise ValueError("bad constant values: pass a float or flat vectoor")

--- a/GPy/mappings/identity.py
+++ b/GPy/mappings/identity.py
@@ -8,7 +8,7 @@ class Identity(Mapping):
     A mapping that does nothing!
     """
     def __init__(self, input_dim, output_dim, name='identity'):
-        Mapping.__init__(self, input_dim, output_dim, name)
+        super(Identity, self).__init__(input_dim, output_dim, name)
 
     def f(self, X):
         return X

--- a/GPy/mappings/kernel.py
+++ b/GPy/mappings/kernel.py
@@ -33,7 +33,7 @@ class Kernel(Mapping):
     """
 
     def __init__(self, input_dim, output_dim, Z, kernel, name='kernmap'):
-        Mapping.__init__(self, input_dim=input_dim, output_dim=output_dim, name=name)
+        super(Kernel, self).__init__(input_dim=input_dim, output_dim=output_dim, name=name)
         self.kern = kernel
         self.Z = Z
         self.num_bases, Zdim = Z.shape

--- a/GPy/mappings/piecewise_linear.py
+++ b/GPy/mappings/piecewise_linear.py
@@ -15,7 +15,7 @@ class PiecewiseLinear(Mapping):
         assert input_dim==1
         assert output_dim==1
 
-        Mapping.__init__(self, input_dim, output_dim, name)
+        super(PiecewiseLinear, self).__init__(input_dim, output_dim, name)
 
         values, breaks = np.array(values).flatten(), np.array(breaks).flatten()
         assert values.size == breaks.size

--- a/GPy/models/bcgplvm.py
+++ b/GPy/models/bcgplvm.py
@@ -30,7 +30,7 @@ class BCGPLVM(GPLVM):
         else:
             assert mapping.input_dim==Y.shape[1], "mapping input dim does not work for Y dimension"
             assert mapping.output_dim==input_dim, "mapping output dim does not work for self.input_dim"
-        GPLVM.__init__(self, Y, input_dim, X=mapping.f(Y), kernel=kernel, name="bcgplvm")
+        super(BCGPLVM, self).__init__(Y, input_dim, X=mapping.f(Y), kernel=kernel, name="bcgplvm")
         self.unlink_parameter(self.X)
         self.mapping = mapping
         self.link_parameter(self.mapping)

--- a/GPy/models/gp_classification.py
+++ b/GPy/models/gp_classification.py
@@ -35,8 +35,8 @@ class GPClassification(GP):
         if inference_method is None:
             inference_method = EP()
 
-        GP.__init__(self, X=X, Y=Y,  kernel=kernel, likelihood=likelihood, inference_method=inference_method,
-                    mean_function=mean_function, name='gp_classification', normalizer=normalizer)
+        super(GPClassification, self).__init__(X=X, Y=Y,  kernel=kernel, likelihood=likelihood, inference_method=inference_method,
+                                               mean_function=mean_function, name='gp_classification', normalizer=normalizer)
 
     @staticmethod
     def from_gp(gp):

--- a/GPy/models/gp_kronecker_gaussian_regression.py
+++ b/GPy/models/gp_kronecker_gaussian_regression.py
@@ -29,7 +29,7 @@ class GPKroneckerGaussianRegression(Model):
 
     """
     def __init__(self, X1, X2, Y, kern1, kern2, noise_var=1., name='KGPR'):
-        Model.__init__(self, name=name)
+        super(GPKroneckerGaussianRegression, self).__init__(name=name)
 
         # accept the construction arguments
         self.X1 = ObsAr(X1)

--- a/GPy/models/sparse_gp_classification.py
+++ b/GPy/models/sparse_gp_classification.py
@@ -46,8 +46,8 @@ class SparseGPClassification(SparseGP):
         if inference_method is None:
             inference_method = EPDTC()
 
-        SparseGP.__init__(self, X, Y, Z, kernel, likelihood, mean_function=mean_function, inference_method=inference_method,
-                          normalizer=normalizer, name='SparseGPClassification', Y_metadata=Y_metadata)
+        super(SparseGPClassification, self).__init__(X, Y, Z, kernel, likelihood, mean_function=mean_function, inference_method=inference_method,
+                                                     normalizer=normalizer, name='SparseGPClassification', Y_metadata=Y_metadata)
 
     @staticmethod
     def from_sparse_gp(sparse_gp):
@@ -136,9 +136,9 @@ class SparseGPClassificationUncertainInput(SparseGP):
 
         X = NormalPosterior(X, X_variance)
 
-        SparseGP.__init__(self, X, Y, Z, kernel, likelihood,
-                          inference_method=EPDTC(),
-                          name='SparseGPClassification', Y_metadata=Y_metadata, normalizer=normalizer)
+        super(SparseGPClassificationUncertainInput, self).__init__(X, Y, Z, kernel, likelihood,
+                                                                   inference_method=EPDTC(), name='SparseGPClassification',
+                                                                   Y_metadata=Y_metadata, normalizer=normalizer)
 
     def parameters_changed(self):
         #Compute the psi statistics for N once, but don't sum out N in psi2

--- a/GPy/models/sparse_gp_minibatch.py
+++ b/GPy/models/sparse_gp_minibatch.py
@@ -43,6 +43,10 @@ class SparseGPMiniBatch(SparseGP):
                  missing_data=False, stochastic=False, batchsize=1):
         self._update_stochastics = False
 
+        # FIXME(?): Half of this function seems to be copy-pasted from
+        #           SparseGP.__init, any particular reason why SparseGP.__init
+        #           is not called (instead of calling GP.__init__ directly)?
+
         # pick a sensible inference method
         if inference_method is None:
             if isinstance(likelihood, likelihoods.Gaussian):
@@ -56,7 +60,8 @@ class SparseGPMiniBatch(SparseGP):
         self.Z = Param('inducing inputs', Z)
         self.num_inducing = Z.shape[0]
 
-        GP.__init__(self, X, Y, kernel, likelihood, inference_method=inference_method, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
+        # Skip SparseGP.__init (see remark above)
+        super(SparseGP, self).__init__(X, Y, kernel, likelihood, inference_method=inference_method, name=name, Y_metadata=Y_metadata, normalizer=normalizer)
         self.missing_data = missing_data
 
         if stochastic and missing_data:

--- a/GPy/models/sparse_gp_regression.py
+++ b/GPy/models/sparse_gp_regression.py
@@ -55,7 +55,7 @@ class SparseGPRegression(SparseGP_MPI):
         else:
             infr = VarDTC()
 
-        SparseGP_MPI.__init__(self, X, Y, Z, kernel, likelihood, mean_function=mean_function,
+        super(SparseGPRegression, self).__init__(X, Y, Z, kernel, likelihood, mean_function=mean_function,
         inference_method=infr, normalizer=normalizer, mpi_comm=mpi_comm, name=name)
 
     def parameters_changed(self):

--- a/GPy/models/sparse_gp_regression_md.py
+++ b/GPy/models/sparse_gp_regression_md.py
@@ -58,7 +58,7 @@ class SparseGPRegressionMD(SparseGP_MPI):
 
         infr = VarDTC_MD()
 
-        SparseGP_MPI.__init__(self, X, Y, Z, kernel, likelihood, inference_method=infr, normalizer=normalizer, mpi_comm=mpi_comm, name=name)
+        super(SparseGPRegressionMD, self).__init__(X, Y, Z, kernel, likelihood, inference_method=infr, normalizer=normalizer, mpi_comm=mpi_comm, name=name)
         self.output_dim = output_dim
 
     def parameters_changed(self):

--- a/GPy/models/sparse_gplvm.py
+++ b/GPy/models/sparse_gplvm.py
@@ -23,7 +23,7 @@ class SparseGPLVM(SparseGPRegression):
             from ..util.initialization import initialize_latent
             X, fracs = initialize_latent(init, input_dim, Y)
         X = Param('latent space', X)
-        SparseGPRegression.__init__(self, X, Y, kernel=kernel, num_inducing=num_inducing)
+        super(SparseGPLVM, self).__init__(X, Y, kernel=kernel, num_inducing=num_inducing)
         self.link_parameter(self.X, 0)
 
     def parameters_changed(self):

--- a/GPy/plotting/matplot_dep/visualize.py
+++ b/GPy/plotting/matplot_dep/visualize.py
@@ -36,7 +36,7 @@ class vpython_show(data_show):
     """
 
     def __init__(self, vals, scene=None):
-        data_show.__init__(self, vals)
+        super(vpython_show, self).__init__(vals)
         # If no axes are defined, create some.
 
         if scene==None:
@@ -54,7 +54,7 @@ class matplotlib_show(data_show):
     the matplotlib_show class is a base class for all visualization methods that use matplotlib. It is initialized with an axis. If the axis is set to None it creates a figure window.
     """
     def __init__(self, vals, axes=None):
-        data_show.__init__(self, vals)
+        super(matplotlib_show, self).__init__(vals)
         # If no axes are defined, create some.
 
         if axes==None:
@@ -72,7 +72,7 @@ class vector_show(matplotlib_show):
     vector elements alongside their indices.
     """
     def __init__(self, vals, axes=None):
-        matplotlib_show.__init__(self, vals, axes)
+        super(vector_show, self).__init__(vals, axes)
         #assert vals.ndim == 2, "Please give a vector in [n x 1] to plot"
         #assert vals.shape[1] == 1, "only showing a vector in one dimension"
         self.size = vals.size
@@ -102,7 +102,7 @@ class lvm(matplotlib_show):
                 vals = model.X.values
         if len(vals.shape)==1:
             vals = vals[None,:]
-        matplotlib_show.__init__(self, vals, axes=latent_axes)
+        super(lvm, self).__init__(vals, axes=latent_axes)
 
         if isinstance(latent_axes,mpl.axes.Axes):
             self.cid = latent_axes.figure.canvas.mpl_connect('button_press_event', self.on_click)
@@ -198,10 +198,10 @@ class lvm_subplots(lvm):
             if i == self.nplots-1:
                 if self.nplots*2!=Model.input_dim:
                     latent_index = [i*2, i*2]
-                lvm.__init__(self, self.latent_vals, Model, data_visualize, axis, sense_axes, latent_index=latent_index)
+                super(lvm_subplots, self).__init__(self.latent_vals, Model, data_visualize, axis, sense_axes, latent_index=latent_index)
             else:
                 latent_index = [i*2, i*2+1]
-                lvm.__init__(self, self.latent_vals, Model, data_visualize, axis, latent_index=latent_index)
+                super(lvm_subplots, self).__init__(self.latent_vals, Model, data_visualize, axis, latent_index=latent_index)
 
 
 
@@ -223,7 +223,7 @@ class lvm_dimselect(lvm):
         else:
             self.sense_axes = sense_axes
         self.labels = labels
-        lvm.__init__(self,vals,model,data_visualize,latent_axes,sense_axes,latent_index)
+        super(lvm_dimselect, self).__init__(vals,model,data_visualize,latent_axes,sense_axes,latent_index)
         self.show_sensitivities()
         print(self.latent_values)
         print("use left and right mouse buttons to select dimensions")
@@ -286,7 +286,7 @@ class image_show(matplotlib_show):
     :type cmap: matplotlib.cm"""
 
     def __init__(self, vals, axes=None, dimensions=(16,16), transpose=False, order='C', invert=False, scale=False, palette=[], preset_mean=0., preset_std=1., select_image=0, cmap=None):
-        matplotlib_show.__init__(self, vals, axes)
+        super(image_show, self).__init__(vals, axes)
         self.dimensions = dimensions
         self.transpose = transpose
         self.order = order
@@ -352,7 +352,7 @@ class mocap_data_show_vpython(vpython_show):
     """Base class for visualizing motion capture data using visual module."""
 
     def __init__(self, vals, scene=None, connect=None, radius=0.1):
-        vpython_show.__init__(self, vals, scene)
+        super(mocap_data_show_vpython, self).__init__(vals, scene)
         self.radius = radius
         self.connect = connect
         self.process_values()
@@ -412,7 +412,7 @@ class mocap_data_show(matplotlib_show):
         if axes==None:
             fig = plt.figure()
             axes = fig.add_subplot(111, projection='3d', aspect='equal')
-        matplotlib_show.__init__(self, vals, axes)
+        super(mocap_data_show, self).__init__(vals, axes)
 
         self.color = color
         self.connect = connect
@@ -496,7 +496,7 @@ class stick_show(mocap_data_show):
     def __init__(self, vals, connect=None, axes=None):
         if len(vals.shape)==1:
             vals = vals[None,:]
-        mocap_data_show.__init__(self, vals, axes=axes, connect=connect)
+        super(stick_show, self).__init__(vals, axes=axes, connect=connect)
 
     def process_values(self):
         self.vals = self.vals.reshape((3, self.vals.shape[1]/3)).T
@@ -515,7 +515,7 @@ class skeleton_show(mocap_data_show):
         self.skel = skel
         self.padding = padding
         connect = skel.connection_matrix()
-        mocap_data_show.__init__(self, vals, axes=axes, connect=connect, color=color)
+        super(skeleton_show, self).__init__(vals, axes=axes, connect=connect, color=color)
     def process_values(self):
         """Takes a set of angles and converts them to the x,y,z coordinates in the internal prepresentation of the class, ready for plotting.
 

--- a/GPy/testing/kernel_tests.py
+++ b/GPy/testing/kernel_tests.py
@@ -61,7 +61,7 @@ class Kern_check_dK_dtheta(Kern_check_model):
     respect to parameters.
     """
     def __init__(self, kernel=None, dL_dK=None, X=None, X2=None):
-        Kern_check_model.__init__(self,kernel=kernel,dL_dK=dL_dK, X=X, X2=X2)
+        super(Kern_check_dK_dtheta, self).__init__(kernel=kernel,dL_dK=dL_dK, X=X, X2=X2)
         self.link_parameter(self.kernel)
 
     def parameters_changed(self):
@@ -74,7 +74,7 @@ class Kern_check_dKdiag_dtheta(Kern_check_model):
     kernel with respect to the parameters.
     """
     def __init__(self, kernel=None, dL_dK=None, X=None):
-        Kern_check_model.__init__(self,kernel=kernel,dL_dK=dL_dK, X=X, X2=None)
+        super(Kern_check_dKdiag_dtheta, self).__init__(kernel=kernel,dL_dK=dL_dK, X=X, X2=None)
         self.link_parameter(self.kernel)
 
     def log_likelihood(self):
@@ -86,7 +86,7 @@ class Kern_check_dKdiag_dtheta(Kern_check_model):
 class Kern_check_dK_dX(Kern_check_model):
     """This class allows gradient checks for the gradient of a kernel with respect to X. """
     def __init__(self, kernel=None, dL_dK=None, X=None, X2=None):
-        Kern_check_model.__init__(self,kernel=kernel,dL_dK=dL_dK, X=X, X2=X2)
+        super(Kern_check_dK_dX, self).__init__(kernel=kernel,dL_dK=dL_dK, X=X, X2=X2)
         self.X = Param('X',X)
         self.link_parameter(self.X)
 
@@ -96,7 +96,7 @@ class Kern_check_dK_dX(Kern_check_model):
 class Kern_check_dKdiag_dX(Kern_check_dK_dX):
     """This class allows gradient checks for the gradient of a kernel diagonal with respect to X. """
     def __init__(self, kernel=None, dL_dK=None, X=None, X2=None):
-        Kern_check_dK_dX.__init__(self,kernel=kernel,dL_dK=dL_dK, X=X, X2=None)
+        super(Kern_check_dKdiag_dX, self).__init__(kernel=kernel,dL_dK=dL_dK, X=X, X2=None)
 
     def log_likelihood(self):
         return (np.diag(self.dL_dK)*self.kernel.Kdiag(self.X)).sum()
@@ -107,7 +107,7 @@ class Kern_check_dKdiag_dX(Kern_check_dK_dX):
 class Kern_check_d2K_dXdX(Kern_check_model):
     """This class allows gradient checks for the secondderivative of a kernel with respect to X. """
     def __init__(self, kernel=None, dL_dK=None, X=None, X2=None):
-        Kern_check_model.__init__(self,kernel=kernel,dL_dK=dL_dK, X=X, X2=X2)
+        super(Kern_check_d2K_dXdX, self).__init__(kernel=kernel,dL_dK=dL_dK, X=X, X2=X2)
         self.X = Param('X',X.copy())
         self.link_parameter(self.X)
         self.Xc = X.copy()
@@ -129,7 +129,7 @@ class Kern_check_d2K_dXdX(Kern_check_model):
 class Kern_check_d2Kdiag_dXdX(Kern_check_model):
     """This class allows gradient checks for the second derivative of a kernel with respect to X. """
     def __init__(self, kernel=None, dL_dK=None, X=None):
-        Kern_check_model.__init__(self,kernel=kernel,dL_dK=dL_dK, X=X)
+        super(Kern_check_d2Kdiag_dXdX, self).__init__(kernel=kernel,dL_dK=dL_dK, X=X)
         self.X = Param('X',X)
         self.link_parameter(self.X)
         self.Xc = X.copy()

--- a/GPy/testing/rv_transformation_tests.py
+++ b/GPy/testing/rv_transformation_tests.py
@@ -15,7 +15,7 @@ class TestModel(GPy.core.Model):
     A simple GPy model with one parameter.
     """
     def __init__(self, theta=1.):
-        GPy.core.Model.__init__(self, 'test_model')
+        super(TestModel, self).__init__('test_model')
         theta = GPy.core.Param('theta', theta)
         self.link_parameter(theta)
 

--- a/GPy/util/mocap.py
+++ b/GPy/util/mocap.py
@@ -163,7 +163,7 @@ def rotation_matrix(xangle, yangle, zangle, order='zxy', degrees=False):
 # Motion capture data routines.
 class skeleton(tree):
     def __init__(self):
-        tree.__init__(self)
+        super(skeleton, self).__init__()
 
     def connection_matrix(self):
         connection = np.zeros((len(self.vertices), len(self.vertices)), dtype=bool)
@@ -197,13 +197,13 @@ class skeleton(tree):
 
 # class bvh_skeleton(skeleton):
 #     def __init__(self):
-#         skeleton.__init__(self)
+#         super(bvh_skeleton, self).__init__()
 
 #     def to_xyz(self, channels):
         
 class acclaim_skeleton(skeleton):
     def __init__(self, file_name=None):
-        skeleton.__init__(self)
+        super(acclaim_skeleton, self).__init__()
         self.documentation = []
         self.angle = 'deg'
         self.length = 1.0


### PR DESCRIPTION
Use `super().__init__` consistently, instead of sometimes calling base class `__init__` directly.

The syntax with `super` was already used almost everywhere in GPy (162 occurences before the proposed patch, 200 occurences after).