### PR TITLE
Fix scipy depency problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We like to pronounce it 'g-pie'.
 
 ## Getting started: installing with pip
 
-We are now requiring the newest version (0.16) of
+We are requiring a recent version (1.3.0 or later) of
 [scipy](http://www.scipy.org/) and thus, we strongly recommend using
 the  [anaconda python distribution](http://continuum.io/downloads).
 With anaconda you can install GPy by the following:
@@ -111,7 +111,7 @@ And finally,
 
     pip install gpy
 
-We've also had luck with [enthought](http://www.enthought.com). Install scipy 0.16 (or later)
+We've also had luck with [enthought](http://www.enthought.com). Install scipy 1.3.0 (or later)
  and then pip install GPy:
 
     pip install gpy

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,11 @@ try:
 except ModuleNotFoundError:
     ext_mods = []
 
+install_requirements = ['numpy>=1.7', 'six', 'paramz>=0.9.0', 'cython>=0.29']
+if sys.version_info < (3, 6):
+    install_requirements += ['scipy>=1.3.0,<1.5.0']
+else:
+    install_requirements += ['scipy>=1.3.0']
 
 setup(name = 'GPy',
       version = __version__,
@@ -164,7 +169,7 @@ setup(name = 'GPy',
       py_modules = ['GPy.__init__'],
       test_suite = 'GPy.testing',
       setup_requires = ['numpy>=1.7'],
-      install_requires = ['numpy>=1.7', 'scipy>=1.3.0', 'six', 'paramz>=0.9.0', 'cython>=0.29'],
+      install_requires = install_requirements,
       extras_require = {'docs':['sphinx'],
                         'optional':['mpi4py',
                                     'ipython>=4.0.0',


### PR DESCRIPTION
Travis builds currently fail with python 3.5 because scipy 1.5 is used (instead of 1.3.x or 1.4.x).

This is a new problem caused by the release of scipy 1.5.0rc1 in May.