### PR TITLE
Fix CI

### DIFF
--- a/GPy/testing/plotting_tests.py
+++ b/GPy/testing/plotting_tests.py
@@ -38,7 +38,7 @@ from nose import SkipTest
 
 try:
     import matplotlib
-    matplotlib.use('agg', warn=False)
+    matplotlib.use('agg')
 except ImportError:
     # matplotlib not installed
     from nose import SkipTest

--- a/travis_tests.py
+++ b/travis_tests.py
@@ -31,7 +31,7 @@
 
 #!/usr/bin/env python
 import matplotlib
-matplotlib.use('agg', warn=False)
+matplotlib.use('agg')
 
 import nose, warnings
 with warnings.catch_warnings():


### PR DESCRIPTION
There was a problem running `travis_tests.py` on my computer and in appveyor whereby a parameter of `matplotlib` that it appears is not present in more recent versions was set. This PR resolves this by changing the call to matplotlib. An alternative solution would be to more tightly define the environments used during testing. 

Anyway, long term I think it might be better to try and support more recent versions of dependencies.