### PR TITLE
Improve kernel tests

### DIFF
--- a/GPy/testing/kernel_tests.py
+++ b/GPy/testing/kernel_tests.py
@@ -176,8 +176,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Positive definite check failed for " + kern.name + " covariance function."))
         pass_checks = False
-        #assert(result)
-        #return False
+
 
     if verbose:
         print("Checking gradients of K(X, X) wrt theta.")
@@ -188,8 +187,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of K(X, X) wrt theta failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dK_dtheta(kern, X=X, X2=None).checkgrad(verbose=True)
         pass_checks = False
-        #assert(result)
-        #return False
+
 
     if verbose:
         print("Checking gradients of K(X, X2) wrt theta.")
@@ -205,8 +203,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of K(X, X) wrt theta failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dK_dtheta(kern, X=X, X2=X2).checkgrad(verbose=True)
         pass_checks = False
-        #assert(result)
-        #return False
+
 
     if verbose:
         print("Checking gradients of Kdiag(X) wrt theta.")
@@ -222,8 +219,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of Kdiag(X) wrt theta failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dKdiag_dtheta(kern, X=X).checkgrad(verbose=True)
         pass_checks = False
-        #assert(result)
-        #return False
+
 
     if verbose:
         print("Checking gradients of K(X, X) wrt X.")
@@ -241,9 +237,8 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of K(X, X) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        #assert(result)
+
         pass_checks = False
-        #return False
 
     if verbose:
         print("Checking gradients of K(X, X2) wrt X.")
@@ -261,9 +256,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of K(X, X2) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        #assert(result)
         pass_checks = False
-        #return False
 
     if verbose:
         print("Checking gradients of Kdiag(X) wrt X.")
@@ -282,8 +275,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of Kdiag(X) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dKdiag_dX(kern, X=X).checkgrad(verbose=True)
         pass_checks = False
-        #assert(result)
-        #return False
+
 
     if verbose:
         print("Checking gradients of dK(X, X2) wrt X2 with full cov in dimensions")
@@ -301,9 +293,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of dK(X, X2) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        #assert(result)
         pass_checks = False
-        #return False
 
     if verbose:
         print("Checking gradients of dK(X, X) wrt X with full cov in dimensions")
@@ -321,9 +311,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of dK(X, X) wrt X with full cov in dimensions failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        #assert(result)
         pass_checks = False
-        #return False
 
     if verbose:
         print("Checking gradients of dKdiag(X, X) wrt X with cov in dimensions")
@@ -341,9 +329,7 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of dKdiag(X, X) wrt X with cov in dimensions failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        #assert(result)
         pass_checks = False
-        #return False
 
     return pass_checks
 

--- a/GPy/testing/kernel_tests.py
+++ b/GPy/testing/kernel_tests.py
@@ -176,8 +176,8 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Positive definite check failed for " + kern.name + " covariance function."))
         pass_checks = False
-        assert(result)
-        return False
+        #assert(result)
+        #return False
 
     if verbose:
         print("Checking gradients of K(X, X) wrt theta.")
@@ -188,8 +188,8 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of K(X, X) wrt theta failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dK_dtheta(kern, X=X, X2=None).checkgrad(verbose=True)
         pass_checks = False
-        assert(result)
-        return False
+        #assert(result)
+        #return False
 
     if verbose:
         print("Checking gradients of K(X, X2) wrt theta.")
@@ -205,8 +205,8 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of K(X, X) wrt theta failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dK_dtheta(kern, X=X, X2=X2).checkgrad(verbose=True)
         pass_checks = False
-        assert(result)
-        return False
+        #assert(result)
+        #return False
 
     if verbose:
         print("Checking gradients of Kdiag(X) wrt theta.")
@@ -222,8 +222,8 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of Kdiag(X) wrt theta failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dKdiag_dtheta(kern, X=X).checkgrad(verbose=True)
         pass_checks = False
-        assert(result)
-        return False
+        #assert(result)
+        #return False
 
     if verbose:
         print("Checking gradients of K(X, X) wrt X.")
@@ -241,9 +241,9 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of K(X, X) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        assert(result)
+        #assert(result)
         pass_checks = False
-        return False
+        #return False
 
     if verbose:
         print("Checking gradients of K(X, X2) wrt X.")
@@ -261,9 +261,9 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of K(X, X2) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        assert(result)
+        #assert(result)
         pass_checks = False
-        return False
+        #return False
 
     if verbose:
         print("Checking gradients of Kdiag(X) wrt X.")
@@ -282,8 +282,8 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
         print(("Gradient of Kdiag(X) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         Kern_check_dKdiag_dX(kern, X=X).checkgrad(verbose=True)
         pass_checks = False
-        assert(result)
-        return False
+        #assert(result)
+        #return False
 
     if verbose:
         print("Checking gradients of dK(X, X2) wrt X2 with full cov in dimensions")
@@ -301,9 +301,9 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of dK(X, X2) wrt X failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        assert(result)
+        #assert(result)
         pass_checks = False
-        return False
+        #return False
 
     if verbose:
         print("Checking gradients of dK(X, X) wrt X with full cov in dimensions")
@@ -321,9 +321,9 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of dK(X, X) wrt X with full cov in dimensions failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        assert(result)
+        #assert(result)
         pass_checks = False
-        return False
+        #return False
 
     if verbose:
         print("Checking gradients of dKdiag(X, X) wrt X with cov in dimensions")
@@ -341,9 +341,9 @@ def check_kernel_gradient_functions(kern, X=None, X2=None, output_ind=None, verb
     if not result:
         print(("Gradient of dKdiag(X, X) wrt X with cov in dimensions failed for " + kern.name + " covariance function. Gradient values as follows:"))
         testmodel.checkgrad(verbose=True)
-        assert(result)
+        #assert(result)
         pass_checks = False
-        return False
+        #return False
 
     return pass_checks
 


### PR DESCRIPTION
Kernel tests are executed against each kernel using the [`check_kernel_gradient_functions`](https://github.com/SheffieldML/GPy/blob/ec20f9ed3a6d98e278a35114e592f1ea098b5531/GPy/testing/kernel_tests.py#L147) function which, in itself, calls and executes a number of tests. Currently, if one of these tests fails or errors, **the subsequent tests do not run**. This PR modifies the code such that if any one test fails or errors, a failure is reported, but the additional tests still run. This means that a developer can fix problems causing tests to fail in any order they like.