### PR TITLE
Fix GPy.priors.InverseGamma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+osx_image: xcode12.2
+
 os:
 - osx
 - linux

--- a/GPy/core/parameterization/priors.py
+++ b/GPy/core/parameterization/priors.py
@@ -358,13 +358,15 @@ class InverseGamma(Gamma):
     domain = _POSITIVE
     _instances = []
 
-    def __init__(self, a, b):
-        self._a = float(a)
-        self._b = float(b)
-        self.constant = -gammaln(self.a) + a * np.log(b)
-
     def __str__(self):
         return "iGa({:.2g}, {:.2g})".format(self.a, self.b)
+
+    def summary(self):
+        return {}
+
+    @staticmethod
+    def from_EV(E, V):
+        raise NotImplementedError
 
     def lnpdf(self, x):
         return self.constant - (self.a + 1) * np.log(x) - self.b / x
@@ -374,7 +376,6 @@ class InverseGamma(Gamma):
 
     def rvs(self, n):
         return 1. / np.random.gamma(scale=1. / self.b, shape=self.a, size=n)
-
 
 class DGPLVM_KFDA(Prior):
     """

--- a/GPy/core/parameterization/priors.py
+++ b/GPy/core/parameterization/priors.py
@@ -357,15 +357,6 @@ class InverseGamma(Gamma):
     """
     domain = _POSITIVE
     _instances = []
-    def __new__(cls, a=1, b=.5): # Singleton:
-        if cls._instances:
-            cls._instances[:] = [instance for instance in cls._instances if instance()]
-            for instance in cls._instances:
-                if instance().a == a and instance().b == b:
-                    return instance()
-        o = super(Prior, cls).__new__(cls, a, b)
-        cls._instances.append(weakref.ref(o))
-        return cls._instances[-1]()
 
     def __init__(self, a, b):
         self._a = float(a)

--- a/GPy/testing/prior_tests.py
+++ b/GPy/testing/prior_tests.py
@@ -55,6 +55,21 @@ class PriorTests(unittest.TestCase):
         m.randomize()
         self.assertTrue(m.checkgrad())
 
+    def test_InverseGamma(self):
+        # Test that this prior object can be instantiated and performs its basic functions
+        # in integration.
+        xmin, xmax = 1, 2.5*np.pi
+        b, C, SNR = 1, 0, 0.1
+        X = np.linspace(xmin, xmax, 500)
+        y  = b*X + C + 1*np.sin(X)
+        y += 0.05*np.random.randn(len(X))
+        X, y = X[:, None], y[:, None]
+        m = GPy.models.GPRegression(X, y)
+        InverseGamma = GPy.priors.InverseGamma(1, 1)
+        m.rbf.set_prior(InverseGamma)
+        m.randomize()
+        self.assertTrue(m.checkgrad())
+
     def test_incompatibility(self):
         xmin, xmax = 1, 2.5*np.pi
         b, C, SNR = 1, 0, 0.1


### PR DESCRIPTION
fixed InverseGamma prior: beforehand, it was a child class of Gamma but it defined a broken __new__ method of its own. Now, it just inherits Gamma's __new__; also added a test that ensures the InverseGamma can be instantiated and integrated into a GPy model