### PR TITLE
Fix TravisCI by updating the macOS version to restore `brew` support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+osx_image: xcode12.2
+
 os:
 - osx
 - linux


### PR DESCRIPTION
The CI is broken. This PR fixes the CI. The root cause is reported in more detail in https://github.com/SheffieldML/GPy/issues/905.

In short, the default macOS version (10.13, see the [TravisCI docs](https://docs.travis-ci.com/user/reference/osx/#macos-version)) used in TravisCI isn't supported by `brew` which caused the `brew install pandoc` in the download_miniconda.sh pre-install script to hang and time out the build. It failed even on inert PRs (adding a line to README, e.g.). Now, with the updated macOS version (from 10.13 to 10.15), `brew` is supported and the `brew install pandoc` command succeeds and allows the remainder of the CI build and test sequence to succeed.