### PR TITLE
Fixing errors causing GPLVM cmu_mocap example to not run properly.

### DIFF
--- a/GPy/examples/dimensionality_reduction.py
+++ b/GPy/examples/dimensionality_reduction.py
@@ -676,6 +676,7 @@ def stick_bgplvm(model=None, optimize=True, verbose=True, plot=True):
 
 
 def cmu_mocap(subject='35', motion=['01'], in_place=True, optimize=True, verbose=True, plot=True):
+    import matplotlib.pyplot as plt
     import GPy
     import pods
 

--- a/GPy/examples/dimensionality_reduction.py
+++ b/GPy/examples/dimensionality_reduction.py
@@ -685,17 +685,23 @@ def cmu_mocap(subject='35', motion=['01'], in_place=True, optimize=True, verbose
         # Make figure move in place.
         data['Y'][:, 0:3] = 0.0
     Y = data['Y']
-    Y_mean = Y.mean(0)
-    Y_std = Y.std(0)
-    m = GPy.models.GPLVM((Y - Y_mean) / Y_std, 2)
+    m = GPy.models.GPLVM(Y, 2, normalizer=True)
 
     if optimize: m.optimize(messages=verbose, max_f_eval=10000)
     if plot:
-        fig, (latent_axes, sense_axes) = plt.subplots(1, 2)
+        fig, _ = plt.subplots(figsize=(8, 5))
+        latent_axes = fig.add_subplot(131)
+        sense_axes = fig.add_subplot(132)
+        viz_axes = fig.add_subplot(133, projection='3d')
+
+
         m.plot_latent(ax=latent_axes)
+        latent_axes.set_aspect('equal')
+
         y = m.Y[0, :]
-        data_show = GPy.plotting.matplot_dep.visualize.skeleton_show(y[None, :], data['skel'])
-        lvm_visualizer = GPy.plotting.matplot_dep.visualize.lvm(m.X[0].copy(), m, data_show, latent_axes=latent_axes)
+        data_show = GPy.plotting.matplot_dep.visualize.skeleton_show(y[None, :], data['skel'], viz_axes)
+
+        lvm_visualizer = GPy.plotting.matplot_dep.visualize.lvm(m.X[0].copy(), m, data_show, latent_axes=latent_axes, sense_axes=sense_axes)        
         input('Press enter to finish')
         lvm_visualizer.close()
         data_show.close()

--- a/GPy/examples/dimensionality_reduction.py
+++ b/GPy/examples/dimensionality_reduction.py
@@ -695,7 +695,7 @@ def cmu_mocap(subject='35', motion=['01'], in_place=True, optimize=True, verbose
         m.plot_latent(ax=latent_axes)
         y = m.Y[0, :]
         data_show = GPy.plotting.matplot_dep.visualize.skeleton_show(y[None, :], data['skel'])
-        lvm_visualizer = GPy.plotting.matplot_dep.visualize.lvm(m.X[0].copy(), m, data_show, latent_axes=ax)
+        lvm_visualizer = GPy.plotting.matplot_dep.visualize.lvm(m.X[0].copy(), m, data_show, latent_axes=latent_axes)
         input('Press enter to finish')
         lvm_visualizer.close()
         data_show.close()

--- a/GPy/examples/dimensionality_reduction.py
+++ b/GPy/examples/dimensionality_reduction.py
@@ -78,7 +78,8 @@ def gplvm_oil_100(optimize=True, verbose=1, plot=True):
     m = GPy.models.GPLVM(Y, 6, kernel=kernel)
     m.data_labels = data['Y'].argmax(axis=1)
     if optimize: m.optimize('scg', messages=verbose)
-    if plot: m.plot_latent(labels=m.data_labels)
+    if plot:
+        m.plot_latent(labels=m.data_labels)
     return m
 
 def sparse_gplvm_oil(optimize=True, verbose=0, plot=True, N=100, Q=6, num_inducing=15, max_iters=50):
@@ -689,7 +690,9 @@ def cmu_mocap(subject='35', motion=['01'], in_place=True, optimize=True, verbose
 
     if optimize: m.optimize(messages=verbose, max_f_eval=10000)
     if plot:
-        ax = m.plot_latent()
+        fig, (latent_axes, sense_axes) = plt.subplots(1, 2)
+        m.plot_latent(ax=latent_axes)
+        ax = gca
         y = m.Y[0, :]
         data_show = GPy.plotting.matplot_dep.visualize.skeleton_show(y[None, :], data['skel'])
         lvm_visualizer = GPy.plotting.matplot_dep.visualize.lvm(m.X[0].copy(), m, data_show, latent_axes=ax)

--- a/GPy/examples/dimensionality_reduction.py
+++ b/GPy/examples/dimensionality_reduction.py
@@ -693,7 +693,6 @@ def cmu_mocap(subject='35', motion=['01'], in_place=True, optimize=True, verbose
     if plot:
         fig, (latent_axes, sense_axes) = plt.subplots(1, 2)
         m.plot_latent(ax=latent_axes)
-        ax = gca
         y = m.Y[0, :]
         data_show = GPy.plotting.matplot_dep.visualize.skeleton_show(y[None, :], data['skel'])
         lvm_visualizer = GPy.plotting.matplot_dep.visualize.lvm(m.X[0].copy(), m, data_show, latent_axes=ax)

--- a/GPy/models/gplvm.py
+++ b/GPy/models/gplvm.py
@@ -14,7 +14,7 @@ class GPLVM(GP):
 
 
     """
-    def __init__(self, Y, input_dim, init='PCA', X=None, kernel=None, name="gplvm"):
+    def __init__(self, Y, input_dim, init='PCA', X=None, kernel=None, name="gplvm", Y_metadata=None, normalizer=False):
 
         """
         :param Y: observed data
@@ -23,6 +23,11 @@ class GPLVM(GP):
         :type input_dim: int
         :param init: initialisation method for the latent space
         :type init: 'PCA'|'random'
+        :param normalizer:
+          normalize the outputs Y.
+          If normalizer is True, we will normalize using Standardize.
+          If normalizer is False (the default), no normalization will be done.
+        :type normalizer: bool
         """
         if X is None:
             from ..util.initialization import initialize_latent
@@ -34,7 +39,7 @@ class GPLVM(GP):
 
         likelihood = Gaussian()
 
-        super(GPLVM, self).__init__(X, Y, kernel, likelihood, name='GPLVM')
+        super(GPLVM, self).__init__(X, Y, kernel, likelihood, name='GPLVM', Y_metadata=Y_metadata, normalizer=normalizer)
 
         self.X = Param('latent_mean', X)
         self.link_parameter(self.X, index=0)

--- a/GPy/plotting/matplot_dep/visualize.py
+++ b/GPy/plotting/matplot_dep/visualize.py
@@ -111,11 +111,11 @@ class lvm(matplotlib_show):
             self.cid = latent_axes.figure.canvas.mpl_connect('axes_leave_event', self.on_leave)
             self.cid = latent_axes.figure.canvas.mpl_connect('axes_enter_event', self.on_enter)
         else:
-            self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('button_press_event', self.on_click)
+            self.cid = latent_axes[0].figure.canvas.mpl_connect('button_press_event', self.on_click)
             if not disable_drag:
-                self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('motion_notify_event', self.on_move)
-            self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('axes_leave_event', self.on_leave)
-            self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('axes_enter_event', self.on_enter)
+                self.cid = latent_axes[0].figure.canvas.mpl_connect('motion_notify_event', self.on_move)
+            self.cid = latent_axes[0].figure.canvas.mpl_connect('axes_leave_event', self.on_leave)
+            self.cid = latent_axes[0].figure.canvas.mpl_connect('axes_enter_event', self.on_enter)
 
         self.data_visualize = data_visualize
         self.model = model

--- a/GPy/plotting/matplot_dep/visualize.py
+++ b/GPy/plotting/matplot_dep/visualize.py
@@ -411,7 +411,7 @@ class mocap_data_show(matplotlib_show):
     def __init__(self, vals, axes=None, connect=None, color='b'):
         if axes==None:
             fig = plt.figure()
-            axes = fig.add_subplot(111, projection='3d', aspect='equal')
+            axes = fig.add_subplot(111, projection='3d') #, aspect='equal') aspect equal not implemented in 3D plots currently see this issue: https://github.com/matplotlib/matplotlib/issues/17172
         super(mocap_data_show, self).__init__(vals, axes)
 
         self.color = color

--- a/GPy/plotting/matplot_dep/visualize.py
+++ b/GPy/plotting/matplot_dep/visualize.py
@@ -39,7 +39,7 @@ class vpython_show(data_show):
         super(vpython_show, self).__init__(vals)
         # If no axes are defined, create some.
 
-        if scene==None:
+        if scene is None:
             self.scene = visual.display(title='Data Visualization')
         else:
             self.scene = scene
@@ -57,7 +57,7 @@ class matplotlib_show(data_show):
         super(matplotlib_show, self).__init__(vals)
         # If no axes are defined, create some.
 
-        if axes==None:
+        if axes is None:
             fig = plt.figure()
             self.axes = fig.add_subplot(111)
         else:
@@ -190,7 +190,7 @@ class lvm_subplots(lvm):
     def __init__(self, vals, Model, data_visualize, latent_axes=None, sense_axes=None):
         self.nplots = int(np.ceil(Model.input_dim/2.))+1
         assert len(latent_axes)==self.nplots
-        if vals==None:
+        if vals is None:
             vals = Model.X[0, :]
         self.latent_values = vals
 
@@ -215,9 +215,9 @@ class lvm_dimselect(lvm):
 
     """
     def __init__(self, vals, model, data_visualize, latent_axes=None, sense_axes=None, latent_index=[0, 1], labels=None):
-        if latent_axes==None and sense_axes==None:
+        if latent_axes is None and sense_axes is None:
             self.fig,(latent_axes,self.sense_axes) = plt.subplots(1,2)
-        elif sense_axes==None:
+        elif sense_axes is None:
             fig=plt.figure()
             self.sense_axes = fig.add_subplot(111)
         else:
@@ -300,7 +300,7 @@ class image_show(matplotlib_show):
         self.set_image(self.vals)
         if not self.palette == []: # Can just show the image (self.set_image() took care of setting the palette)
             self.handle = self.axes.imshow(self.vals, interpolation='nearest')
-        elif cmap==None: # Use a jet map.
+        elif cmap is None: # Use a jet map.
             self.handle = self.axes.imshow(self.vals, cmap=plt.cm.jet, interpolation='nearest') # @UndefinedVariable
         else: # Use the selected map.
             self.handle = self.axes.imshow(self.vals, cmap=cmap, interpolation='nearest') # @UndefinedVariable
@@ -368,7 +368,7 @@ class mocap_data_show_vpython(vpython_show):
     def draw_edges(self):
         self.rods = []
         self.line_handle = []
-        if not self.connect==None:
+        if self.connect is not None:
             self.I, self.J = np.nonzero(self.connect)
             for i, j in zip(self.I, self.J):
                 pos, axis = self.pos_axis(i, j)
@@ -380,7 +380,7 @@ class mocap_data_show_vpython(vpython_show):
 
     def modify_edges(self):
         self.line_handle = []
-        if not self.connect==None:
+        if self.connect is not None:
             self.I, self.J = np.nonzero(self.connect)
             for rod, i, j in zip(self.rods, self.I, self.J):
                 rod.pos, rod.axis = self.pos_axis(i, j)
@@ -409,7 +409,7 @@ class mocap_data_show(matplotlib_show):
     """Base class for visualizing motion capture data."""
 
     def __init__(self, vals, axes=None, connect=None, color='b'):
-        if axes==None:
+        if axes is None:
             fig = plt.figure()
             axes = fig.add_subplot(111, projection='3d') #, aspect='equal') aspect equal not implemented in 3D plots currently see this issue: https://github.com/matplotlib/matplotlib/issues/17172
         super(mocap_data_show, self).__init__(vals, axes)
@@ -428,7 +428,7 @@ class mocap_data_show(matplotlib_show):
 
     def draw_edges(self):
         self.line_handle = []
-        if not self.connect==None:
+        if self.connect is not None:
             x = []
             y = []
             z = []

--- a/GPy/plotting/matplot_dep/visualize.py
+++ b/GPy/plotting/matplot_dep/visualize.py
@@ -111,11 +111,11 @@ class lvm(matplotlib_show):
             self.cid = latent_axes.figure.canvas.mpl_connect('axes_leave_event', self.on_leave)
             self.cid = latent_axes.figure.canvas.mpl_connect('axes_enter_event', self.on_enter)
         else:
-            self.cid = latent_axes[0].figure.canvas.mpl_connect('button_press_event', self.on_click)
+            self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('button_press_event', self.on_click)
             if not disable_drag:
-                self.cid = latent_axes[0].figure.canvas.mpl_connect('motion_notify_event', self.on_move)
-            self.cid = latent_axes[0].figure.canvas.mpl_connect('axes_leave_event', self.on_leave)
-            self.cid = latent_axes[0].figure.canvas.mpl_connect('axes_enter_event', self.on_enter)
+                self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('motion_notify_event', self.on_move)
+            self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('axes_leave_event', self.on_leave)
+            self.cid = latent_axes['scatter'].figure.canvas.mpl_connect('axes_enter_event', self.on_enter)
 
         self.data_visualize = data_visualize
         self.model = model

--- a/GPy/util/normalizer.py
+++ b/GPy/util/normalizer.py
@@ -4,7 +4,7 @@ Created on Aug 27, 2014
 @author: Max Zwiessele
 '''
 import numpy as np
-
+import warnings
 
 class _Norm(object):
     def __init__(self):

--- a/GPy/util/normalizer.py
+++ b/GPy/util/normalizer.py
@@ -90,7 +90,7 @@ class Standardize(_Norm):
         Y = np.ma.masked_invalid(Y, copy=False)
         self.mean = Y.mean(0).view(np.ndarray)
         self.std = Y.std(0).view(np.ndarray)
-        if np.any(self.std) == 0:
+        if np.any(self.std == 0):
             self.std[np.where(Y_std==0)]=1.
             warnings.warn("Some values of Y have standard deviation of zero. Resetting to 1.0 to avoid divide by zero errors.")
 

--- a/GPy/util/normalizer.py
+++ b/GPy/util/normalizer.py
@@ -90,6 +90,9 @@ class Standardize(_Norm):
         Y = np.ma.masked_invalid(Y, copy=False)
         self.mean = Y.mean(0).view(np.ndarray)
         self.std = Y.std(0).view(np.ndarray)
+        if np.any(self.std) == 0:
+            self.std[np.where(Y_std==0)]=1.
+            warnings.warn("Some values of Y have standard deviation of zero. Resetting to 1.0 to avoid divide by zero errors.")
 
     def normalize(self, Y):
         super(Standardize, self).normalize(Y)

--- a/GPy/util/normalizer.py
+++ b/GPy/util/normalizer.py
@@ -92,7 +92,8 @@ class Standardize(_Norm):
         self.std = Y.std(0).view(np.ndarray)
         if np.any(self.std == 0):
             warnings.warn("Some values of Y have standard deviation of zero. Resetting to 1.0 to avoid divide by zero errors.")
-            self.std[np.where(self.std==0)]=1.
+           # Choice of setting to 1.0 is somewhat arbitrary. It avoids a divide by zero error, but setting to EPS would also do this. Don't have strong reasons for choosing 1.0, it was just first instinct 
+            self.std[np.where(self.std==0)]=1. 
 
     def normalize(self, Y):
         super(Standardize, self).normalize(Y)

--- a/GPy/util/normalizer.py
+++ b/GPy/util/normalizer.py
@@ -91,8 +91,8 @@ class Standardize(_Norm):
         self.mean = Y.mean(0).view(np.ndarray)
         self.std = Y.std(0).view(np.ndarray)
         if np.any(self.std == 0):
-            self.std[np.where(Y_std==0)]=1.
             warnings.warn("Some values of Y have standard deviation of zero. Resetting to 1.0 to avoid divide by zero errors.")
+            self.std[np.where(self.std==0)]=1.
 
     def normalize(self, Y):
         super(Standardize, self).normalize(Y)


### PR DESCRIPTION
Various errors in the dimensionality reduction example cmu_mocap that required fixes elsewhere including:

1) Use of == to compare objects to None.
2) Missing ability to normalise inputs to GPLVM (as available in base class GP)
3) Standardize() normaliser class not checking for when standard deviations zero, leading to a silent "nan" error (fixed by warning of standard deviation zero, and setting std to 1.0
4) Changes to output of plot_latent() which meant it wasn't returning an axes object as the demo expected (fix in demo code).