### PR TITLE
Fix ignoring arguments passed to save_model.

### DIFF
--- a/GPy/models/gp_classification.py
+++ b/GPy/models/gp_classification.py
@@ -56,7 +56,7 @@ class GPClassification(GP):
         return GPClassification.from_gp(m)
 
     def save_model(self, output_filename, compress=True, save_data=True):
-        self._save_model(output_filename, compress=True, save_data=True)
+        self._save_model(output_filename, compress=compress, save_data=save_data)
 
     @staticmethod
     def _build_from_input_dict(input_dict, data=None):

--- a/GPy/models/gp_regression.py
+++ b/GPy/models/gp_regression.py
@@ -54,4 +54,4 @@ class GPRegression(GP):
         return GPRegression.from_gp(m)
 
     def save_model(self, output_filename, compress=True, save_data=True):
-        self._save_model(output_filename, compress=True, save_data=True)
+        self._save_model(output_filename, compress=compress, save_data=save_data)


### PR DESCRIPTION
Before this change, defaults were passed to _save_model, rather than the
correct arguments the user supplied to save_model.