### PR TITLE
Fix for matplotlib>=3.4.0

### DIFF
--- a/GPy/plotting/matplot_dep/plot_definitions.py
+++ b/GPy/plotting/matplot_dep/plot_definitions.py
@@ -241,8 +241,8 @@ class MatplotlibPlots(AbstractPlottingLibrary):
             except ImportError:
                 from matplotlib.mlab import contiguous_regions
             # Handle united data, such as dates
-            ax._process_unit_info(xdata=X, ydata=y1)
-            ax._process_unit_info(ydata=y2)
+            ax._process_unit_info([("x", X), ("y", y1)], convert=False)
+            ax._process_unit_info([("y", y2)], convert=False)
             # Convert the arrays so we can work with them
             from numpy import ma
             x = ma.masked_invalid(ax.convert_xunits(X))


### PR DESCRIPTION
The arguments to `_process_unit_info` changed in matplotlib 3.4.0 (current latest is 3.5.1). This pull request makes the required change.

Note that this will of course break for installations with matplotlib<3.4.0.

Related issue: #953 