### PR TITLE
Fixing broken kernels due to the add_parameter --> link_parameter rename

### DIFF
--- a/GPy/kern/src/todo/symmetric.py
+++ b/GPy/kern/src/todo/symmetric.py
@@ -24,7 +24,7 @@ class Symmetric(Kernpart):
         self.num_params = k.num_params
         self.name = k.name + '_symm'
         self.k = k
-        self.add_parameter(k)
+        self.link_parameter(k)
         #self._set_params(k._get_params())
 
     def K(self,X,X2,target):

--- a/GPy/kern/src/trunclinear.py
+++ b/GPy/kern/src/trunclinear.py
@@ -51,8 +51,8 @@ class TruncLinear(Kern):
 
         self.variances = Param('variances', variances, Logexp())
         self.delta = Param('delta', delta)
-        self.add_parameter(self.variances)
-        self.add_parameter(self.delta)
+        self.link_parameter(self.variances)
+        self.link_parameter(self.delta)
 
     @Cache_this(limit=3)
     def K(self, X, X2=None):
@@ -146,7 +146,7 @@ class TruncLinear_inf(Kern):
                 variances = np.ones(self.input_dim)
 
         self.variances = Param('variances', variances, Logexp())
-        self.add_parameter(self.variances)
+        self.link_parameter(self.variances)
 
 
 #     @Cache_this(limit=3)


### PR DESCRIPTION
Some kernels got left behind when add_parameter was renamed to link_parameter (and then migrated out into Paramz). This patch fixes those oversights, and addresses issue #791. 

(Sorry about the whitespace changes...)