### PR TITLE
fix: Fixed to add_to_canvas() returns ax instead of plots

### DIFF
--- a/GPy/plotting/matplot_dep/plot_definitions.py
+++ b/GPy/plotting/matplot_dep/plot_definitions.py
@@ -90,7 +90,7 @@ class MatplotlibPlots(AbstractPlottingLibrary):
             #ax.legend(prop=fontdict)
             legend_ontop(ax, ncol=legend, fontdict=fontdict)
         if title is not None: ax.figure.suptitle(title)
-        return plots
+        return ax
 
     def show_canvas(self, ax, **kwargs):
         ax.figure.canvas.draw()

--- a/GPy/testing/plotting_tests.py
+++ b/GPy/testing/plotting_tests.py
@@ -362,7 +362,6 @@ def test_threed():
     ]], extensions=extensions):
         yield (do_test, )
 
-
 def test_sparse():
     np.random.seed(11111)
     import matplotlib

--- a/GPy/testing/plotting_tests.py
+++ b/GPy/testing/plotting_tests.py
@@ -298,6 +298,23 @@ def test_plot():
                                                                                       'samples', 'in_error']], extensions=extensions):
         yield (do_test, )
 
+
+def test_show():
+    np.random.seed(111)
+    import matplotlib
+    matplotlib.rcParams.update(matplotlib.rcParamsDefault)
+    matplotlib.rcParams[u'text.usetex'] = False
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        X = np.random.uniform(-3.,3.,(20,1))
+        Y = np.sin(X) + np.random.randn(20,1)*0.05
+        kernel = GPy.kern.RBF(input_dim=1, variance=1., lengthscale=1.)
+        m = GPy.models.GPRegression(X,Y,kernel)
+        fig = m.plot()
+        GPy.plotting.show(fig, filename='show fig test')
+
+
 def test_twod():
     np.random.seed(11111)
     import matplotlib
@@ -344,6 +361,7 @@ def test_threed():
         'gp_3d_{}'.format(sub) for sub in ["data", "mean", 'inducing',
     ]], extensions=extensions):
         yield (do_test, )
+
 
 def test_sparse():
     np.random.seed(11111)


### PR DESCRIPTION
I want to fix the error which is discussed in #920.

The `plotting.show()` function is a alias of the `show_canvas()` method and it expect for an `ax` object in matplotlib, while the `GP.plot()`(==`add_to_canvas()`) function returns `plots` dict.

See also:
https://github.com/SheffieldML/GPy/blob/f63ed48b0d4bf043868a0a1729d28003c13fe263/GPy/plotting/matplot_dep/plot_definitions.py#L95-L97

To fix this, I just replace the return value of `add_to_canvas()` from `plots` to `ax`.

Note:
The return value of the `add_to_canvas()` function was changed at the commit 4f3047e035b60bf5a9f49acfa8dcd6a267e22a08 from `ax` to `plots`.
Unfortunately, I could not find the reason why this fix was needed.

I would appreciate it if you reviewed this.
