### PR TITLE
Enhance multioutput grad obs

### DIFF
--- a/GPy/examples/regression.py
+++ b/GPy/examples/regression.py
@@ -771,7 +771,7 @@ def multioutput_gp_with_derivative_observations(plot=True):
 
     return m
 
-def multioutput_gp_with_derivative_observations_2D():
+def multioutput_gp_with_derivative_observations_2D(optimize=True, plot=False):
     '''
     This in an example on how to use a MultioutputGP model with gradient
     observations and multiple single-dimensional kernels of differing types.
@@ -846,7 +846,8 @@ def multioutput_gp_with_derivative_observations_2D():
     # create the MultioutputGP model and optimize
     model = GPy.models.MultioutputGP(X_list, Y_list, kern_list, likelihood_list)
     model.likelihood.constrain_fixed()
-    model.optimize()
+    if optimize:
+        model.optimize()
 
     # make function predictions
     Xnew, _, ind = GPy.util.multioutput.build_XY([grid], index=[0])
@@ -860,7 +861,26 @@ def multioutput_gp_with_derivative_observations_2D():
 
     mu_d, var_d = model.predict(Xnew, Y_metadata=Y_metadata)
 
-    mu_d = np.array([mu_d[:len(grid)], mu_d[len(grid):]]).T
-    var_d = np.array([var_d[:len(grid)], var_d[len(grid):]]).T
+    mu_d = np.array([mu_d[:len(grid)], mu_d[len(grid):]]).T[0]
+    var_d = np.array([var_d[:len(grid)], var_d[len(grid):]]).T[0]
+
+    if plot and MPL_AVAILABLE:
+        fig, axs = plt.subplots(1, 3)
+        for ax in axs: ax.set_box_aspect(1)
+        axs[0].set_title('true f')
+        axs[0].contourf(xx, yy, fgrid.reshape(ppa, ppa), levels=25)
+        axs[1].set_title('true df1')
+        axs[1].contourf(xx, yy, dfgrid[:,0].reshape(ppa, ppa), levels=25)
+        axs[2].set_title('true df2')
+        axs[2].contourf(xx, yy, dfgrid[:,1].reshape(ppa, ppa), levels=25)
+
+        fig, axs = plt.subplots(1, 3)
+        for ax in axs: ax.set_box_aspect(1)
+        axs[0].set_title('pred f')
+        axs[0].contourf(xx, yy, mu.reshape(ppa, ppa), levels=25)
+        axs[1].set_title('pred df1')
+        axs[1].contourf(xx, yy, mu_d[:,0].reshape(ppa, ppa), levels=25)
+        axs[2].set_title('pred df2')
+        axs[2].contourf(xx, yy, mu_d[:,1].reshape(ppa, ppa), levels=25)
 
     return model

--- a/GPy/examples/regression.py
+++ b/GPy/examples/regression.py
@@ -770,3 +770,97 @@ def multioutput_gp_with_derivative_observations(plot=True):
     mu, var = m.predict_noiseless(Xnew=[xpred, np.empty((0, 1))])
 
     return m
+
+def multioutput_gp_with_derivative_observations_2D():
+    '''
+    This in an example on how to use a MultioutputGP model with gradient
+    observations and multiple single-dimensional kernels of differing types.
+    '''
+
+    period = 3
+    w = 2*np.pi/period # angular frequency
+    bounds = (-period, period)
+
+    # latent function and gradient
+    f = lambda x: (np.exp(-x[:,0]**2) + np.cos(w*x[:,1]))[:,None]
+    df = lambda x: np.array([-2*np.exp(-x[:,0]**2)*x[:,0], -w*np.sin(w*x[:,1])]).T
+
+    # 2D input grid
+    ppa = 25 # points per axis
+    x = np.linspace(*bounds, ppa)
+    xx, yy = np.meshgrid(x, x)
+    grid = np.array([xx.reshape(-1), yy.reshape(-1)]).T
+
+    fgrid = f(grid)
+    dfgrid = df(grid)
+
+    # 10 random training points generated with a space-filling sobol sequence
+    X = np.array([
+        [ 0.50421399,  2.1331483 ],
+        [-2.15717152, -1.70295936],
+        [-1.46704334,  1.37111521],
+        [ 2.79064536, -0.9649018 ],
+        [ 1.60728264,  0.27702713],
+        [-0.30712366, -0.57372129],
+        [-2.6140632 ,  2.49192488],
+        [ 0.89078772, -2.85873686],
+        [ 1.15813136,  0.96910322],
+        [-2.83307021, -1.38155383]
+    ])
+
+    # Note!
+    # This example uses the same inputs for function and gradient observations.
+
+    noise_std = 1e-2
+    # function observations
+    Y = f(X) + np.random.normal(scale=noise_std, size=(len(X), 1))
+    # gradient observations
+    dY = df(X) + np.random.normal(scale=noise_std, size=(len(X), 2))
+
+    # gather inputs and observations into lists
+    X_list = [X, X, X]
+    # once for function observations, and once for each partial derivative
+    # make sure all arrays are of shape (N x dims), where N is # of training points
+    Y_list = [Y, dY[:,0,None], dY[:,1,None]]
+
+    # create a kernel that is the product of two one-dimensional kernels
+    # the first kernel is an RBF kernel
+    kern0 = GPy.kern.RBF(input_dim=1, active_dims=[0])
+    # as the function is periodic in the second dimension, we use a StdP kernel
+    kern1 = GPy.kern.StdPeriodic(input_dim=1, active_dims=[1], period=period)
+    kern1.period.constrain_fixed()
+    # the kernels can be multiplied together into a product kernel
+    kern = kern0 * kern1
+
+    # with gradient observations, we need to define a DiffKern for each dimension
+    # the DiffKern is given the main kernel as a base kernel
+    diffkern0 = GPy.kern.DiffKern(kern, 0)
+    diffkern1 = GPy.kern.DiffKern(kern, 1)
+
+    # gather the main kernel and diffkerns into a list
+    kern_list = [kern, diffkern0, diffkern1]
+
+    # define a likelihood and repeat it in a list
+    likelihood_list = [GPy.likelihoods.Gaussian(variance=noise_std**2)]*3
+
+    # create the MultioutputGP model and optimize
+    model = GPy.models.MultioutputGP(X_list, Y_list, kern_list, likelihood_list)
+    model.likelihood.constrain_fixed()
+    model.optimize()
+
+    # make function predictions
+    Xnew, _, ind = GPy.util.multioutput.build_XY([grid], index=[0])
+    Y_metadata={'output_index': ind, 'trials': np.ones(ind.shape)}
+
+    mu, var = model.predict(Xnew, Y_metadata=Y_metadata)
+
+    # make gradient predictions
+    Xnew, _, ind = GPy.util.multioutput.build_XY([grid]*2, index=[1, 2])
+    Y_metadata={'output_index': ind, 'trials': np.ones(ind.shape)}
+
+    mu_d, var_d = model.predict(Xnew, Y_metadata=Y_metadata)
+
+    mu_d = np.array([mu_d[:len(grid)], mu_d[len(grid):]]).T
+    var_d = np.array([var_d[:len(grid)], var_d[len(grid):]]).T
+
+    return model

--- a/GPy/kern/src/diff_kern.py
+++ b/GPy/kern/src/diff_kern.py
@@ -23,12 +23,12 @@ class DiffKern(Kern):
         self.base_kern.parameters_changed()
 
     @Cache_this(limit=3, ignore_args=())
-    def K(self, X, X2=None, dimX2 = None): #X in dimension self.dimension
+    def K(self, X, X2=None, dimX2=None): #X in dimension self.dimension
         if X2 is None:
             X2 = X
         if dimX2 is None:
             dimX2 = self.dimension
-        return self.base_kern.dK2_dXdX2(X,X2, self.dimension, dimX2)
+        return self.base_kern.dK2_dXdX2(X, X2, self.dimension, dimX2)
 
     @Cache_this(limit=3, ignore_args=())
     def dK_dX(self, X, X2, dimX, dimX2=None):
@@ -46,11 +46,11 @@ class DiffKern(Kern):
 
     @Cache_this(limit=3, ignore_args=())
     def dK_dX_wrap(self, X, X2): #X in dimension self.dimension
-        return self.base_kern.dK_dX(X,X2, self.dimension)
+        return self.base_kern.dK_dX(X, X2, self.dimension)
 
     @Cache_this(limit=3, ignore_args=())
     def dK_dX2_wrap(self, X, X2): #X in dimension self.dimension
-        return self.base_kern.dK_dX2(X,X2, self.dimension)
+        return self.base_kern.dK_dX2(X, X2, self.dimension)
 
     @Cache_this(limit=3, ignore_args=())
     def dK2_dXdX2_wrap(self, X, X2, dimX):
@@ -74,32 +74,32 @@ class DiffKern(Kern):
     def update_gradients_full(self, dL_dK, X, X2=None, dimX2=None):
         if dimX2 is None:
             dimX2 = self.dimension
-        gradients = self.base_kern.dgradients2_dXdX2(X,X2,self.dimension,dimX2)
+        gradients = self.base_kern.dgradients2_dXdX2(X, X2, self.dimension, dimX2)
         self.base_kern.update_gradients_direct(*[self._convert_gradients(dL_dK, gradient) for gradient in gradients])
 
     def update_gradients_diag(self, dL_dK_diag, X):
-        gradients = self.base_kern.dgradients2_dXdX2(X,X, self.dimension, self.dimension)
+        gradients = self.base_kern.dgradients2_dXdX2(X, X, self.dimension, self.dimension)
         self.base_kern.update_gradients_direct(*[self._convert_gradients(dL_dK_diag, gradient, f=np.diag) for gradient in gradients])
 
     def update_gradients_dK_dX(self, dL_dK, X, X2=None):
         if X2 is None:
             X2 = X
-        gradients = self.base_kern.dgradients_dX(X,X2, self.dimension)
+        gradients = self.base_kern.dgradients_dX(X, X2, self.dimension)
         self.base_kern.update_gradients_direct(*[self._convert_gradients(dL_dK, gradient) for gradient in gradients])
 
     def update_gradients_dK_dX2(self, dL_dK, X, X2=None):
-        gradients = self.base_kern.dgradients_dX2(X,X2, self.dimension)
+        gradients = self.base_kern.dgradients_dX2(X, X2, self.dimension)
         self.base_kern.update_gradients_direct(*[self._convert_gradients(dL_dK, gradient) for gradient in gradients])
 
     def gradients_X(self, dL_dK, X, X2):
-        tmp = self.base_kern.gradients_XX(dL_dK, X, X2)[:,:,:, self.dimension]
+        tmp = self.base_kern.gradients_XX(dL_dK, X, X2)[:,:,:,self.dimension]
         return np.sum(tmp, axis=1)
     
     def gradients_X2(self, dL_dK, X, X2):
-        tmp = self.base_kern.gradients_XX(dL_dK, X, X2)[:, :, self.dimension, :]
+        tmp = self.base_kern.gradients_XX(dL_dK, X, X2)[:,:,self.dimension,:]
         return np.sum(tmp, axis=1)
 
-    def _convert_gradients(self, l,g, f = lambda x:x):
+    def _convert_gradients(self, l, g, f=lambda x:x):
         if type(g) is np.ndarray:
             return np.sum(f(l)*f(g))
         else:

--- a/GPy/kern/src/diff_kern.py
+++ b/GPy/kern/src/diff_kern.py
@@ -31,18 +31,18 @@ class DiffKern(Kern):
         return self.base_kern.dK2_dXdX2(X,X2, self.dimension, dimX2)
 
     @Cache_this(limit=3, ignore_args=())
-    def dK_dX(self, X, X2, dim_pred_grads, dimX2=None):
+    def dK_dX(self, X, X2, dimX, dimX2=None):
         if dimX2 is None:
             dimX2 = self.dimension
-        return self.base_kern.dK3_dXdXdX2(X, X2, dim_pred_grads, self.dimension, dimX2)
+        return self.base_kern.dK3_dXdXdX2(X, X2, dimX, self.dimension, dimX2)
 
     @Cache_this(limit=3, ignore_args=())
     def Kdiag(self, X):
         return self.base_kern.dK2_dXdX2diag(X, self.dimension, self.dimension)
 
     @Cache_this(limit=3, ignore_args=())
-    def dK_dXdiag(self, X, dim_pred_grads):
-        return self.base_kern.dK3_dXdXdX2diag(X, dim_pred_grads, self.dimension)
+    def dK_dXdiag(self, X, dimX):
+        return self.base_kern.dK3_dXdXdX2diag(X, dimX, self.dimension, self.dimension)
 
     @Cache_this(limit=3, ignore_args=())
     def dK_dX_wrap(self, X, X2): #X in dimension self.dimension
@@ -53,12 +53,12 @@ class DiffKern(Kern):
         return self.base_kern.dK_dX2(X,X2, self.dimension)
 
     @Cache_this(limit=3, ignore_args=())
-    def dK2_dXdX2_wrap(self, X, X2, dim_pred_grads):
-        return self.base_kern.dK2_dXdX2(X, X2, dim_pred_grads, self.dimension)
+    def dK2_dXdX2_wrap(self, X, X2, dimX):
+        return self.base_kern.dK2_dXdX2(X, X2, dimX, self.dimension)
 
     @Cache_this(limit=3, ignore_args=())
-    def dK2_dXdX_wrap(self, X, X2, dim_pred_grads):
-        return self.base_kern.dK2_dXdX(X, X2, dim_pred_grads, self.dimension)
+    def dK2_dXdX_wrap(self, X, X2, dimX):
+        return self.base_kern.dK2_dXdX(X, X2, dimX, self.dimension)
 
     def reset_gradients(self):
         self.base_kern.reset_gradients()

--- a/GPy/kern/src/diff_kern.py
+++ b/GPy/kern/src/diff_kern.py
@@ -29,11 +29,21 @@ class DiffKern(Kern):
         if dimX2 is None:
             dimX2 = self.dimension
         return self.base_kern.dK2_dXdX2(X,X2, self.dimension, dimX2)
- 
+
+    @Cache_this(limit=3, ignore_args=())
+    def dK_dX(self, X, X2, dim_pred_grads, dimX2=None):
+        if dimX2 is None:
+            dimX2 = self.dimension
+        return self.base_kern.dK3_dXdXdX2(X, X2, dim_pred_grads, self.dimension, dimX2)
+
     @Cache_this(limit=3, ignore_args=())
     def Kdiag(self, X):
-        return np.diag(self.base_kern.dK2_dXdX2(X,X, self.dimension, self.dimension))
-    
+        return self.base_kern.dK2_dXdX2diag(X, self.dimension, self.dimension)
+
+    @Cache_this(limit=3, ignore_args=())
+    def dK_dXdiag(self, X, dim_pred_grads):
+        return self.base_kern.dK3_dXdXdX2diag(X, dim_pred_grads, self.dimension)
+
     @Cache_this(limit=3, ignore_args=())
     def dK_dX_wrap(self, X, X2): #X in dimension self.dimension
         return self.base_kern.dK_dX(X,X2, self.dimension)
@@ -41,6 +51,14 @@ class DiffKern(Kern):
     @Cache_this(limit=3, ignore_args=())
     def dK_dX2_wrap(self, X, X2): #X in dimension self.dimension
         return self.base_kern.dK_dX2(X,X2, self.dimension)
+
+    @Cache_this(limit=3, ignore_args=())
+    def dK2_dXdX2_wrap(self, X, X2, dim_pred_grads):
+        return self.base_kern.dK2_dXdX2(X, X2, dim_pred_grads, self.dimension)
+
+    @Cache_this(limit=3, ignore_args=())
+    def dK2_dXdX_wrap(self, X, X2, dim_pred_grads):
+        return self.base_kern.dK2_dXdX(X, X2, dim_pred_grads, self.dimension)
 
     def reset_gradients(self):
         self.base_kern.reset_gradients()

--- a/GPy/kern/src/kernel_slice_operations.py
+++ b/GPy/kern/src/kernel_slice_operations.py
@@ -35,6 +35,7 @@ class KernCallsViaSlicerMeta(ParametersChangedMeta):
         put_clean(dct, 'gradients_XX_diag', _slice_gradients_XX_diag)
         put_clean(dct, 'gradients_X_diag', _slice_gradients_X_diag)
 
+        put_clean(dct, 'dgradients',_slice_K)
         put_clean(dct, 'dgradients_dX',_slice_partial_gradients_list_X)
         put_clean(dct, 'dgradients_dX2',_slice_partial_gradients_list_X)
         put_clean(dct, 'dgradients2_dXdX2',_slice_partial_gradients_list_XX)

--- a/GPy/kern/src/kernel_slice_operations.py
+++ b/GPy/kern/src/kernel_slice_operations.py
@@ -22,7 +22,11 @@ class KernCallsViaSlicerMeta(ParametersChangedMeta):
         put_clean(dct, 'dK_dX', _slice_dK_dX)
         put_clean(dct, 'dK_dX2', _slice_dK_dX)
         put_clean(dct, 'dK2_dXdX2', _slice_dK2_dXdX2)
+        put_clean(dct, 'dK2_dXdX', _slice_dK2_dXdX2)
+        put_clean(dct, 'dK3_dXdXdX2', _slice_dK3_dXdXdX2)
         put_clean(dct, 'Kdiag', _slice_Kdiag)
+        put_clean(dct, 'dK2_dXdX2diag', _slice_dK2_dXdX2diag)
+        put_clean(dct, 'dK2_dXdXdiag', _slice_dK2_dXdX2diag)
         put_clean(dct, 'phi', _slice_Kdiag)
         put_clean(dct, 'update_gradients_full', _slice_update_gradients_full)
         put_clean(dct, 'update_gradients_diag', _slice_update_gradients_diag)
@@ -166,6 +170,33 @@ def _slice_dK2_dXdX2(f):
                 ret = np.zeros((X.shape[0], X2.shape[0]))
             else:
                 ret = f(self, s.X, s.X2, d, d2, *a, **kw)
+        return ret
+    return wrap
+
+def _slice_dK2_dXdX2diag(f):
+    @wraps(f)
+    def wrap(self, X, dimX, dimX2, *a, **kw):
+        with _Slice_wrap(self, X, None) as s:
+            d = s.k._project_dim(dimX)
+            d2 = s.k._project_dim(dimX2)
+            if (d is None) or (d2 is None):
+                ret = np.zeros(X.shape[0])
+            else:
+                ret = f(self, s.X, d, d2, *a, **kw)
+        return ret
+    return wrap
+
+def _slice_dK3_dXdXdX2(f):
+    @wraps(f)
+    def wrap(self, X, X2, dim, dimX, dimX2, *a, **kw):
+        with _Slice_wrap(self, X, X2) as s:
+            D = s.k._project_dim(dim)
+            d = s.k._project_dim(dimX)
+            d2 = s.k._project_dim(dimX2)
+            if (D is None) or (d is None) or (d2 is None):
+                ret = np.zeros((X.shape[0], X2.shape[0]))
+            else:
+                ret = f(self, s.X, s.X2, D, d, d2, *a, **kw)
         return ret
     return wrap
 

--- a/GPy/kern/src/multioutput_derivative_kern.py
+++ b/GPy/kern/src/multioutput_derivative_kern.py
@@ -7,15 +7,19 @@ import numpy as np
 from functools import partial
 
 class KernWrapper(Kern):
-    def __init__(self, fk, fug, fg, base_kern):
+    def __init__(self, fk, fug, fg, fkdx, base_kern):
         self.fk = fk
         self.fug = fug
         self.fg = fg
+        self.fkdx = fkdx
         self.base_kern = base_kern
         super(KernWrapper, self).__init__(base_kern.active_dims.size, base_kern.active_dims, name='KernWrapper',useGPU=False)
 
     def K(self, X, X2=None):
         return self.fk(X,X2=X2)
+
+    def dK_dX(self, X, X2, dim_pred_grads):
+        return self.fkdx(X, X2, dim_pred_grads)
     
     def update_gradients_full(self,dL_dK, X, X2=None):
         return self.fug(dL_dK, X, X2=X2)
@@ -67,12 +71,12 @@ class MultioutputDerivativeKern(MultioutputKern):
                 elif cross_covariances.get((i,j)) is not None: #cross covariance is given
                     kern = cross_covariances.get((i,j))
                 elif kernels[i].name == 'DiffKern' and kernels[i].base_kern == kernels[j]: # one is derivative of other
-                    kern = KernWrapper(kernels[i].dK_dX_wrap,kernels[i].update_gradients_dK_dX,kernels[i].gradients_X, kernels[j])
+                    kern = KernWrapper(kernels[i].dK_dX_wrap,kernels[i].update_gradients_dK_dX,kernels[i].gradients_X,kernels[i].dK2_dXdX_wrap, kernels[j])
                     unique=False
                 elif kernels[j].name == 'DiffKern' and kernels[j].base_kern == kernels[i]: # one is derivative of other
-                    kern = KernWrapper(kernels[j].dK_dX2_wrap,kernels[j].update_gradients_dK_dX2,kernels[j].gradients_X2, kernels[i])
+                    kern = KernWrapper(kernels[j].dK_dX2_wrap,kernels[j].update_gradients_dK_dX2,kernels[j].gradients_X2,kernels[j].dK2_dXdX2_wrap, kernels[i])
                 elif kernels[i].name == 'DiffKern' and kernels[j].name == 'DiffKern' and kernels[i].base_kern == kernels[j].base_kern: #both are partial derivatives
-                    kern = KernWrapper(partial(kernels[i].K, dimX2=kernels[j].dimension), partial(kernels[i].update_gradients_full, dimX2=kernels[j].dimension),None, kernels[i].base_kern)
+                    kern = KernWrapper(partial(kernels[i].K, dimX2=kernels[j].dimension), partial(kernels[i].update_gradients_full, dimX2=kernels[j].dimension),None, partial(kernels[i].dK_dX, dimX2=kernels[j].dimension), kernels[i].base_kern)
                     if i>j:
                         unique=False
                 else:

--- a/GPy/kern/src/multioutput_derivative_kern.py
+++ b/GPy/kern/src/multioutput_derivative_kern.py
@@ -18,8 +18,8 @@ class KernWrapper(Kern):
     def K(self, X, X2=None):
         return self.fk(X,X2=X2)
 
-    def dK_dX(self, X, X2, dim_pred_grads):
-        return self.fkdx(X, X2, dim_pred_grads)
+    def dK_dX(self, X, X2, dimX):
+        return self.fkdx(X, X2, dimX)
     
     def update_gradients_full(self,dL_dK, X, X2=None):
         return self.fug(dL_dK, X, X2=X2)

--- a/GPy/kern/src/multioutput_kern.py
+++ b/GPy/kern/src/multioutput_kern.py
@@ -176,10 +176,7 @@ class MultioutputKern(CombinationKernel):
                             )
 
     def update_gradients_diag(self, dL_dKdiag, X):
-        if X2 is None:
-            X2 = X
         slices = index_to_slices(X[:,self.index_dim])
-        slices2 = index_to_slices(X2[:,self.index_dim])
 
         self.reset_gradients()
         for i in range(len(slices)):

--- a/GPy/kern/src/multioutput_kern.py
+++ b/GPy/kern/src/multioutput_kern.py
@@ -85,23 +85,23 @@ class MultioutputKern(CombinationKernel):
         self.link_parameters(*[kernels[i] for i in linked])
         
     @Cache_this(limit=3, ignore_args=())
-    def K(self, X ,X2=None):
+    def K(self, X, X2=None):
         if X2 is None:
             X2 = X
         slices = index_to_slices(X[:,self.index_dim])
         slices2 = index_to_slices(X2[:,self.index_dim])
         target =  np.zeros((X.shape[0], X2.shape[0]))
-        [[[[ target.__setitem__((slices[i][k],slices2[j][l]), self.covariance[i][j].K(X[slices[i][k],:],X2[slices2[j][l],:])) for k in range( len(slices[i]))] for l in range(len(slices2[j])) ] for i in range(len(slices))] for j in range(len(slices2))]  
+        [[[[ target.__setitem__((slices[i][k],slices2[j][l]), self.covariance[i][j].K(X[slices[i][k],:],X2[slices2[j][l],:])) for k in range( len(slices[i]))] for l in range(len(slices2[j])) ] for i in range(len(slices))] for j in range(len(slices2))]
         return target
 
     @Cache_this(limit=3, ignore_args=())
-    def dK_dX(self, X, X2, dim_pred_grads):
+    def dK_dX(self, X, X2, dimX):
         if X2 is None:
             X2 = X
         slices = index_to_slices(X[:,self.index_dim])
         slices2 = index_to_slices(X2[:,self.index_dim])
         target =  np.zeros((X.shape[0], X2.shape[0]))
-        [[[[ target.__setitem__((slices[i][k],slices2[j][l]), self.covariance[i][j].dK_dX(X[slices[i][k],:],X2[slices2[j][l],:],dim_pred_grads)) for k in range( len(slices[i]))] for l in range(len(slices2[j])) ] for i in range(len(slices))] for j in range(len(slices2))]
+        [[[[ target.__setitem__((slices[i][k],slices2[j][l]), self.covariance[i][j].dK_dX(X[slices[i][k],:],X2[slices2[j][l],:],dimX)) for k in range( len(slices[i]))] for l in range(len(slices2[j])) ] for i in range(len(slices))] for j in range(len(slices2))]
         return target
 
     @Cache_this(limit=3, ignore_args=())
@@ -113,11 +113,11 @@ class MultioutputKern(CombinationKernel):
         return target
 
     @Cache_this(limit=3, ignore_args=())
-    def dK_dXdiag(self, X, dim_pred_grads):
+    def dK_dXdiag(self, X, dimX):
         slices = index_to_slices(X[:,self.index_dim])
         kerns = itertools.repeat(self.kern) if self.single_kern else self.kern
         target = np.zeros(X.shape[0])
-        [[np.copyto(target[s], kern.dK_dXdiag(X[s], dim_pred_grads)) for s in slices_i] for kern, slices_i in zip(kerns, slices)]
+        [[np.copyto(target[s], kern.dK_dXdiag(X[s], dimX)) for s in slices_i] for kern, slices_i in zip(kerns, slices)]
         return target
     
     def _update_gradients_full_wrapper(self, kern, dL_dK, X, X2):

--- a/GPy/kern/src/prod.py
+++ b/GPy/kern/src/prod.py
@@ -80,10 +80,15 @@ class Prod(CombinationKernel):
         Compute the derivative of K with respect to:
             dimension dimX of set X.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros((X.shape[0], X2.shape[0]))
-        for combination in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.K(X, X2) for p in combination])
-            to_update = list(set(self.parts) - set(combination))[0]
+        for combination in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination) > 0:
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update = list(set(which_parts) - set(combination))[0]
             prod_sum += prod*to_update.dK_dX(X, X2, dimX)
         return prod_sum
 
@@ -95,10 +100,15 @@ class Prod(CombinationKernel):
 
         Returns only diagonal elements.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros(X.shape[0])
-        for combination in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.Kdiag(X) for p in combination])
-            to_update = list(set(self.parts) - set(combination))[0]
+        for combination in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination) > 0:
+                prod = reduce(np.multiply, [p.Kdiag(X) for p in combination])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update = list(set(which_parts) - set(combination))[0]
             prod_sum += prod*to_update.dK_dXdiag(X, dimX)
         return prod_sum
 
@@ -108,10 +118,15 @@ class Prod(CombinationKernel):
         Compute the derivative of K with respect to:
             dimension dimX2 of set X2.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros((X.shape[0], X2.shape[0]))
-        for combination in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.K(X, X2) for p in combination])
-            to_update = list(set(self.parts) - set(combination))[0]
+        for combination in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination) > 0:
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update = list(set(which_parts) - set(combination))[0]
             prod_sum += prod*to_update.dK_dX2(X, X2, dimX2)
         return prod_sum
 
@@ -122,18 +137,24 @@ class Prod(CombinationKernel):
             dimension dimX of set X, and
             dimension dimX2 of set X2.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros((X.shape[0], X2.shape[0]))
-        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
-            to_update1 = list(set(self.parts) - set(combination1))[0]
+        for combination1 in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination1) > 0:
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update1 = list(set(which_parts) - set(combination1))[0]
             prod_sum += prod*to_update1.dK2_dXdX2(X, X2, dimX, dimX2)
-            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
-                if len(combination2) > 0:
-                    prod = reduce(np.multiply, [p.K(X, X2) for p in combination2])
-                else:
-                    prod = np.ones(prod_sum.shape)
-                to_update2 = list(set(combination1) - set(combination2))[0]
-                prod_sum += prod*to_update1.dK_dX(X, X2, dimX)*to_update2.dK_dX2(X, X2, dimX2)
+            if len(which_parts) > 1:
+                for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                    if len(combination2) > 0:
+                        prod = reduce(np.multiply, [p.K(X, X2) for p in combination2])
+                    else:
+                        prod = np.ones(prod_sum.shape)
+                    to_update2 = list(set(combination1) - set(combination2))[0]
+                    prod_sum += prod*to_update1.dK_dX(X, X2, dimX)*to_update2.dK_dX2(X, X2, dimX2)
         return prod_sum
 
     @Cache_this(limit=3, force_kwargs=['which_parts'])
@@ -145,18 +166,24 @@ class Prod(CombinationKernel):
 
         Returns only diagonal elements.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros(X.shape[0])
-        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.Kdiag(X) for p in combination1])
-            to_update1 = list(set(self.parts) - set(combination1))[0]
+        for combination1 in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination1) > 0:
+                prod = reduce(np.multiply, [p.Kdiag(X) for p in combination1])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update1 = list(set(which_parts) - set(combination1))[0]
             prod_sum += prod*to_update1.dK2_dXdX2diag(X, dimX, dimX2)
-            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
-                if len(combination2) > 0:
-                    prod = reduce(np.multiply, [p.Kdiag(X) for p in combination2])
-                else:
-                    prod = np.ones(prod_sum.shape)
-                to_update2 = list(set(combination1) - set(combination2))[0]
-                prod_sum += prod*to_update1.dK_dXdiag(X, dimX)*to_update2.dK_dX2diag(X, dimX)
+            if len(which_parts) > 1:
+                for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                    if len(combination2) > 0:
+                        prod = reduce(np.multiply, [p.Kdiag(X) for p in combination2])
+                    else:
+                        prod = np.ones(prod_sum.shape)
+                    to_update2 = list(set(combination1) - set(combination2))[0]
+                    prod_sum += prod*to_update1.dK_dXdiag(X, dimX)*to_update2.dK_dX2diag(X, dimX)
         return prod_sum
 
     @Cache_this(limit=3, force_kwargs=['which_parts'])
@@ -166,18 +193,24 @@ class Prod(CombinationKernel):
             dimension dimX_0 of set X, and
             dimension dimX_1 of set X.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros((X.shape[0], X2.shape[0]))
-        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
-            to_update1 = list(set(self.parts) - set(combination1))[0]
+        for combination1 in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination1) > 0:
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update1 = list(set(which_parts) - set(combination1))[0]
             prod_sum += prod*to_update1.dK2_dXdX(X, X2, dimX_0, dimX_1)
-            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
-                if len(combination2) > 0:
-                    prod = reduce(np.multiply, [p.K(X, X2) for p in combination2])
-                else:
-                    prod = np.ones(prod_sum.shape)
-                to_update2 = list(set(combination1) - set(combination2))[0]
-                prod_sum += prod*to_update1.dK_dX(X, X2, dimX_0)*to_update2.dK_dX(X, X2, dimX_1)
+            if len(which_parts) > 1:
+                for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                    if len(combination2) > 0:
+                        prod = reduce(np.multiply, [p.K(X, X2) for p in combination2])
+                    else:
+                        prod = np.ones(prod_sum.shape)
+                    to_update2 = list(set(combination1) - set(combination2))[0]
+                    prod_sum += prod*to_update1.dK_dX(X, X2, dimX_0)*to_update2.dK_dX(X, X2, dimX_1)
         return prod_sum
 
     @Cache_this(limit=3, force_kwargs=['which_parts'])
@@ -188,28 +221,34 @@ class Prod(CombinationKernel):
             dimension dimX_1 of set X, and
             dimension dimX2 of set X2.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros((X.shape[0], X2.shape[0]))
-        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
-            to_update1 = list(set(self.parts) - set(combination1))[0]
+        for combination1 in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination1) > 0:
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update1 = list(set(which_parts) - set(combination1))[0]
             prod_sum += prod*to_update1.dK3_dXdXdX2(X, X2, dimX_0, dimX_1, dimX2)
-            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
-                if len(combination2) > 0:
-                    prod = reduce(np.multiply, [p.K(X, X2) for p in combination2])
-                else:
-                    prod = np.ones(prod_sum.shape)
-                to_update2 = list(set(combination1) - set(combination2))[0]
-                prod_sum += prod*to_update1.dK2_dXdX2(X, X2, dimX_0, dimX2)*to_update2.dK_dX(X, X2, dimX_1)
-                prod_sum += prod*to_update1.dK2_dXdX(X, X2, dimX_0, dimX_1)*to_update2.dK_dX2(X, X2, dimX2)
-                prod_sum += prod*to_update1.dK_dX(X, X2, dimX_0)*to_update2.dK2_dXdX2(X, X2, dimX_1, dimX2)
-                if len(self.parts) > 2:
-                    for combination3 in itertools.combinations(combination2, len(combination2) - 1):
-                        if len(combination3) > 0:
-                            prod = reduce(np.multiply, [p.K(X, X2) for p in combination3])
-                        else:
-                            prod = np.ones(prod_sum.shape)
-                        to_update3 = list(set(combination2) - set(combination3))[0]
-                        prod_sum += prod*to_update1.dK_dX(X, X2, dimX_0)*to_update2.dK_dX2(X, X2, dimX2)*to_update3.dK_dX(X, X2, dimX_1)
+            if len(which_parts) > 1:
+                for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                    if len(combination2) > 0:
+                        prod = reduce(np.multiply, [p.K(X, X2) for p in combination2])
+                    else:
+                        prod = np.ones(prod_sum.shape)
+                    to_update2 = list(set(combination1) - set(combination2))[0]
+                    prod_sum += prod*to_update1.dK2_dXdX2(X, X2, dimX_0, dimX2)*to_update2.dK_dX(X, X2, dimX_1)
+                    prod_sum += prod*to_update1.dK2_dXdX(X, X2, dimX_0, dimX_1)*to_update2.dK_dX2(X, X2, dimX2)
+                    prod_sum += prod*to_update1.dK_dX(X, X2, dimX_0)*to_update2.dK2_dXdX2(X, X2, dimX_1, dimX2)
+                    if len(which_parts) > 2:
+                        for combination3 in itertools.combinations(combination2, len(combination2) - 1):
+                            if len(combination3) > 0:
+                                prod = reduce(np.multiply, [p.K(X, X2) for p in combination3])
+                            else:
+                                prod = np.ones(prod_sum.shape)
+                            to_update3 = list(set(combination2) - set(combination3))[0]
+                            prod_sum += prod*to_update1.dK_dX(X, X2, dimX_0)*to_update2.dK_dX2(X, X2, dimX2)*to_update3.dK_dX(X, X2, dimX_1)
         return prod_sum
 
     @Cache_this(limit=3, force_kwargs=['which_parts'])
@@ -222,28 +261,34 @@ class Prod(CombinationKernel):
 
         Returns only diagonal elements of the covariance matrix.
         """
+        if which_parts is None:
+            which_parts = self.parts
         prod_sum = np.zeros(X.shape[0])
-        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
-            prod = reduce(np.multiply, [p.Kdiag(X) for p in combination1])
-            to_update1 = list(set(self.parts) - set(combination1))[0]
+        for combination1 in itertools.combinations(which_parts, len(which_parts) - 1):
+            if len(combination1) > 0:
+                prod = reduce(np.multiply, [p.Kdiag(X) for p in combination1])
+            else:
+                prod = np.ones(prod_sum.shape)
+            to_update1 = list(set(which_parts) - set(combination1))[0]
             prod_sum += prod*to_update1.dK3_dXdXdX2diag(X, dimX_0, dimX_1, dimX2)
-            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
-                if len(combination2) > 0:
-                    prod = reduce(np.multiply, [p.Kdiag(X) for p in combination2])
-                else:
-                    prod = np.ones(prod_sum.shape)
-                to_update2 = list(set(combination1) - set(combination2))[0]
-                prod_sum += prod*to_update1.dK2_dXdX2diag(X, dimX_0, dimX2)*to_update2.dK_dXdiag(X, dimX_1)
-                prod_sum += prod*to_update1.dK2_dXdXdiag(X, dimX_0, dimX_1)*to_update2.dK_dX2diag(X, dimX2)
-                prod_sum += prod*to_update1.dK_dXdiag(X, dimX_0)*to_update2.dK2_dXdX2diag(X, dimX_1, dimX2)
-                if len(self.parts) > 2:
-                    for combination3 in itertools.combinations(combination2, len(combination2) - 1):
-                        if len(combination3) > 0:
-                            prod = reduce(np.multiply, [p.Kdiag(X) for p in combination3])
-                        else:
-                            prod = np.ones(prod_sum.shape)
-                        to_update3 = list(set(combination2) - set(combination3))[0]
-                        prod_sum += prod*to_update1.dK_dXdiag(X, dimX_0)*to_update2.dK_dX2diag(X, dimX2)*to_update3.dK_dXdiag(X, dimX_1)
+            if len(which_parts) > 1:
+                for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                    if len(combination2) > 0:
+                        prod = reduce(np.multiply, [p.Kdiag(X) for p in combination2])
+                    else:
+                        prod = np.ones(prod_sum.shape)
+                    to_update2 = list(set(combination1) - set(combination2))[0]
+                    prod_sum += prod*to_update1.dK2_dXdX2diag(X, dimX_0, dimX2)*to_update2.dK_dXdiag(X, dimX_1)
+                    prod_sum += prod*to_update1.dK2_dXdXdiag(X, dimX_0, dimX_1)*to_update2.dK_dX2diag(X, dimX2)
+                    prod_sum += prod*to_update1.dK_dXdiag(X, dimX_0)*to_update2.dK2_dXdX2diag(X, dimX_1, dimX2)
+                    if len(which_parts) > 2:
+                        for combination3 in itertools.combinations(combination2, len(combination2) - 1):
+                            if len(combination3) > 0:
+                                prod = reduce(np.multiply, [p.Kdiag(X) for p in combination3])
+                            else:
+                                prod = np.ones(prod_sum.shape)
+                            to_update3 = list(set(combination2) - set(combination3))[0]
+                            prod_sum += prod*to_update1.dK_dXdiag(X, dimX_0)*to_update2.dK_dX2diag(X, dimX2)*to_update3.dK_dXdiag(X, dimX_1)
         return prod_sum
 
     def update_gradients_direct(self, *args):
@@ -251,56 +296,82 @@ class Prod(CombinationKernel):
             p.update_gradients_direct(*g)
 
     def dgradients_dX(self, X, X2, dimX, parts=None):
+        """
+        Compute the hyperparameter gradients of:
+            the derivative of K with respect to dimension dimX of set X
+            ("dK_dX").
+        """
         if parts is None:
-            parts=self.parts
+            parts = self.parts
         gradients = []
         for part in parts:
-            dgradients_i = part.dgradients(X, X2)
-            dgradients_dX_i = part.dgradients_dX(X, X2, dimX)
             neq_parts = [p for p in parts if p is not part]
-            if len(neq_parts)>0:
-                K_rest = self.K(X,X2, which_parts = neq_parts)
-                K_rest_dX = self.dK_dX(X,X2,dimX, which_parts=neq_parts)
+
+            if len(neq_parts) > 0:
+                K = self.K(X, X2, which_parts=neq_parts)
+                K_dx = self.dK_dX(X, X2, dimX, which_parts=neq_parts)
             else:
-                K_rest = np.ones((X.shape[0], X2.shape[0]))
-                K_res_dX = np.zeros((X.shape[0], X2.shape[0]))
-            gradients += [ [ g_dX*K_rest + g*K_rest_dX   for i, (g,g_dX) in enumerate(zip(dgradients_i, dgradients_dX_i))] ]
+                K = np.ones((X.shape[0], X2.shape[0]))
+                K_dx = np.zeros((X.shape[0], X2.shape[0]))
+
+            g = part.dgradients(X, X2)
+            g_dx = part.dgradients_dX(X, X2, dimX)
+
+            gradients += [[(g_i*K_dx + g_dx_i*K) for (g_i, g_dx_i) in zip(g, g_dx)]]
             
         return gradients
 
     def dgradients_dX2(self, X, X2, dimX2, parts=None):
+        """
+        Compute the hyperparameter gradients of:
+            the derivative of K with respect to dimension dimX2 of set X2
+            ("dK_dX2").
+        """
         if parts is None:
-            parts=self.parts
+            parts = self.parts
         gradients = []
         for part in parts:
-            dgradients_i = part.dgradients(X, X2)
-            dgradients_dX_i = part.dgradients_dX2(X, X2, dimX2)
             neq_parts = [p for p in parts if p is not part]
-            if len(neq_parts)>0:
-                K_rest = self.K(X,X2, which_parts = neq_parts)
-                K_rest_dX = self.dK_dX(X,X2,dimX2, which_parts=neq_parts)
+
+            if len(neq_parts) > 0:
+                K = self.K(X, X2, which_parts=neq_parts)
+                K_dx2 = self.dK_dX2(X, X2, dimX2, which_parts=neq_parts)
             else:
-                K_rest = np.ones((X.shape[0], X2.shape[0]))
-                K_res_dX = np.zeros((X.shape[0], X2.shape[0]))
-            gradients += [ [ g_dX*K_rest + g*K_rest_dX   for g, g_dX in zip(dgradients_i, dgradients_dX_i)] ]
+                K = np.ones((X.shape[0], X2.shape[0]))
+                K_dx2 = np.zeros((X.shape[0], X2.shape[0]))
+
+            g = part.dgradients(X, X2)
+            g_dx2 = part.dgradients_dX2(X, X2, dimX2)
+
+            gradients += [[(g_i*K_dx2 + g_dx2_i*K) for (g_i, g_dx2_i) in zip(g, g_dx2)]]
             
         return gradients
 
     def dgradients2_dXdX2(self, X, X2, dimX, dimX2, parts=None):
+        """
+        Compute the hyperparameter gradients of:
+            the second derivative of K with respect to:
+                dimension dimX of set X, and
+                dimension dimX2 of set X2
+            ("dK2_dXdX2").
+        """
         if parts is None:
-            parts=self.parts
+            parts = self.parts
         gradients = []
         for part in parts:
-            g_dxdx2 = part.dgradients2_dXdX2(X,X2,dimX,dimX2)
-            g_dx = part.dgradients_dX(X,X2,dimX)
-            g_dx2 = part.dgradients_dX2(X,X2,dimX2)
-            g = part.dgradients(X, X2)
-            neq_parts = [p for p in self.parts if p is not part]
+            neq_parts = [p for p in parts if p is not part]
+
+            K = self.K(X, X2, which_parts=neq_parts)
+            K_dx = self.dK_dX(X, X2, dimX, which_parts=neq_parts)
+            K_dx2 = self.dK_dX2(X, X2, dimX2, which_parts=neq_parts)
             K_dxdx2 = self.dK2_dXdX2(X, X2, dimX, dimX2, which_parts=neq_parts)
-            K_dx = self.dK_dX(X,X2,dimX, which_parts=neq_parts)
-            K_dx2 = self.dK_dX2(X,X2,dimX2, which_parts=neq_parts)
-            K = self.K(X, X2)
-            gradients += [[ g_i*K_dxdx2 + g_dx_i*K_dx2 + g_dx2_i*K_dx + g_dxdx2_i*K for g_i, g_dx_i, g_dx2_i, g_dxdx2_i in zip(g, g_dx, g_dx2, g_dxdx2)]]
+
+            g = part.dgradients(X, X2)
+            g_dx = part.dgradients_dX(X, X2, dimX)
+            g_dx2 = part.dgradients_dX2(X, X2, dimX2)
+            g_dxdx2 = part.dgradients2_dXdX2(X, X2, dimX, dimX2)
+
+            gradients += [[(g_i*K_dxdx2 + g_dx_i*K_dx2 + g_dx2_i*K_dx + g_dxdx2_i*K) for (g_i, g_dx_i, g_dx2_i, g_dxdx2_i) in zip(g, g_dx, g_dx2, g_dxdx2)]]
         return gradients
 
     def update_gradients_full(self, dL_dK, X, X2=None):

--- a/GPy/kern/src/prod.py
+++ b/GPy/kern/src/prod.py
@@ -92,7 +92,16 @@ class Prod(CombinationKernel):
             prod_sum += prod*to_update.dK_dX2(X, X2, dimX2)
         return prod_sum
 
-    @Cache_this(limit=3, force_kwargs=['which_parts'])    
+    @Cache_this(limit=3, force_kwargs=['which_parts'])
+    def dK_dXdiag(self, X, dimX, which_parts=None):
+        prod_sum = np.zeros(X.shape[0])
+        for combination in itertools.combinations(self.parts, len(self.parts) - 1):
+            prod = reduce(np.multiply, [p.Kdiag(X) for p in combination])
+            to_update = list(set(self.parts) - set(combination))[0]
+            prod_sum += prod*to_update.dK_dXdiag(X, dimX)
+        return prod_sum
+
+    @Cache_this(limit=3, force_kwargs=['which_parts'])
     def dK2_dXdX2(self, X, X2, dimX, dimX2, which_parts=None):
         prod_sum = np.zeros((X.shape[0], X2.shape[0]))
         for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
@@ -103,6 +112,72 @@ class Prod(CombinationKernel):
                 prod = reduce(np.multiply, [p.K(X, X2) for p in combination2]) if len(combination2) > 0 else np.ones(prod_sum.shape)
                 to_update2 = list(set(combination1)-set(combination2))[0]
                 prod_sum += prod*to_update1.dK_dX(X, X2, dimX)*to_update2.dK_dX2(X, X2, dimX2)
+        return prod_sum
+
+    @Cache_this(limit=3, force_kwargs=['which_parts'])
+    def dK2_dXdX(self, X, X2, dim_pred_grads, dimX, which_parts=None):
+        prod_sum = np.zeros((X.shape[0], X2.shape[0]))
+        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
+            prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
+            to_update1 = list(set(self.parts) - set(combination1))[0]
+            prod_sum += prod*to_update1.dK2_dXdX(X, X2, dim_pred_grads, dimX)
+            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination2]) if len(combination2) > 0 else np.ones(prod_sum.shape)
+                to_update2 = list(set(combination1)-set(combination2))[0]
+                prod_sum += prod*to_update1.dK_dX(X, X2, dim_pred_grads)*to_update2.dK_dX(X, X2, dimX)
+        return prod_sum
+
+    @Cache_this(limit=3, force_kwargs=['which_parts'])
+    def dK2_dXdX2diag(self, X, dimX, dimX2, which_parts=None):
+        prod_sum = np.zeros(X.shape[0])
+        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
+            prod = reduce(np.multiply, [p.Kdiag(X) for p in combination1])
+            to_update1 = list(set(self.parts) - set(combination1))[0]
+            prod_sum += prod*to_update1.dK2_dXdX2diag(X, dimX, dimX2)
+            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                prod = reduce(np.multiply, [p.Kdiag(X) for p in combination2]) if len(combination2) > 0 else np.ones(prod_sum.shape)
+                to_update2 = list(set(combination1)-set(combination2))[0]
+                prod_sum += prod*to_update1.dK_dXdiag(X, dimX)*to_update2.dK_dX2diag(X, dimX)
+        return prod_sum
+
+    @Cache_this(limit=3, force_kwargs=['which_parts'])
+    def dK3_dXdXdX2(self, X, X2, dim_pred_grads, dimX, dimX2, which_parts=None):
+        prod_sum = np.zeros((X.shape[0], X2.shape[0]))
+        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
+            prod = reduce(np.multiply, [p.K(X, X2) for p in combination1])
+            to_update1 = list(set(self.parts) - set(combination1))[0]
+            prod_sum += prod*to_update1.dK3_dXdXdX2(X, X2, dim_pred_grads, dimX, dimX2)
+            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                prod = reduce(np.multiply, [p.K(X, X2) for p in combination2]) if len(combination2) > 0 else np.ones(prod_sum.shape)
+                to_update2 = list(set(combination1)-set(combination2))[0]
+                prod_sum += prod*to_update1.dK2_dXdX2(X, X2, dim_pred_grads, dimX2)*to_update2.dK_dX(X, X2, dimX)
+                prod_sum += prod*to_update1.dK2_dXdX(X, X2, dim_pred_grads, dimX)*to_update2.dK_dX2(X, X2, dimX2)
+                prod_sum += prod*to_update1.dK_dX(X, X2, dim_pred_grads)*to_update2.dK2_dXdX2(X, X2, dimX, dimX2)
+                if len(self.parts) > 2:
+                    for combination3 in itertools.combinations(combination2, len(combination2) - 1):
+                        prod = reduce(np.multiply, [p.K(X, X2) for p in combination3]) if len(combination3) > 0 else np.ones(prod_sum.shape)
+                        to_update3 = list(set(combination2)-set(combination3))[0]
+                        prod_sum += prod*to_update1.dK_dX(X, X2, dim_pred_grads)*to_update2.dK_dX2(X, X2, dimX2)*to_update3.dK_dX(X, X2, dimX)
+        return prod_sum
+
+    @Cache_this(limit=3, force_kwargs=['which_parts'])
+    def dK3_dXdXdX2diag(self, X, dim_pred_grads, dimX, which_parts=None):
+        prod_sum = np.zeros(X.shape[0])
+        for combination1 in itertools.combinations(self.parts, len(self.parts) - 1):
+            prod = reduce(np.multiply, [p.Kdiag(X) for p in combination1])
+            to_update1 = list(set(self.parts) - set(combination1))[0]
+            prod_sum += prod*to_update1.dK3_dXdXdX2diag(X, dim_pred_grads, dimX)
+            for combination2 in itertools.combinations(combination1, len(combination1) - 1):
+                prod = reduce(np.multiply, [p.Kdiag(X) for p in combination2]) if len(combination2) > 0 else np.ones(prod_sum.shape)
+                to_update2 = list(set(combination1)-set(combination2))[0]
+                prod_sum += prod*to_update1.dK2_dXdX2diag(X, dim_pred_grads, dimX)*to_update2.dK_dXdiag(X, dimX)
+                prod_sum += prod*to_update1.dK2_dXdXdiag(X, dim_pred_grads, dimX)*to_update2.dK_dX2diag(X, dimX)
+                prod_sum += prod*to_update1.dK_dXdiag(X, dim_pred_grads)*to_update2.dK2_dXdX2diag(X, dimX, dimX)
+                if len(self.parts) > 2:
+                    for combination3 in itertools.combinations(combination2, len(combination2) - 1):
+                        prod = reduce(np.multiply, [p.Kdiag(X) for p in combination3]) if len(combination3) > 0 else np.ones(prod_sum.shape)
+                        to_update3 = list(set(combination2)-set(combination3))[0]
+                        prod_sum += prod*to_update1.dK_dXdiag(X, dim_pred_grads)*to_update2.dK_dX2diag(X, dimX)*to_update3.dK_dXdiag(X, dimX)
         return prod_sum
 
     def update_gradients_direct(self, *args):

--- a/GPy/kern/src/rbf.py
+++ b/GPy/kern/src/rbf.py
@@ -163,12 +163,12 @@ class RBF(Stationary):
         return term*self._clean_K(X, X2)
 
     @Cache_this(limit=3, ignore_args=())
-    def dK3_dXdXdX2diag(self, X, dimX_0, dimX_1):
+    def dK3_dXdXdX2diag(self, X, dimX_0, dimX_1, dimX2):
         """
         Compute the third derivative of K with respect to:
             dimension dimX_0 of set X,
             dimension dimX_1 of set X, and
-            dimension dimX_1 of set X2.
+            dimension dimX2 of set X2.
 
         Returns only diagonal elements of the covariance matrix.
         """

--- a/GPy/kern/src/standard_periodic.py
+++ b/GPy/kern/src/standard_periodic.py
@@ -14,7 +14,6 @@ Neural Networks and Machine Learning, pages 133-165. Springer, 1998.
 
 from .kern import Kern
 from ...core.parameterization import Param
-from paramz.caching import Cache_this
 from paramz.transformations import Logexp
 
 import numpy as np
@@ -123,7 +122,6 @@ class StdPeriodic(Kern):
 
         pass
 
-    @Cache_this(limit=3, ignore_args=())
     def K(self, X, X2=None):
         """Compute the covariance matrix between X and X2."""
         if X2 is None:
@@ -140,7 +138,6 @@ class StdPeriodic(Kern):
         ret[:] = self.variance
         return ret
 
-    @Cache_this(limit=3, ignore_args=())
     def dK_dX(self, X, X2, dimX):
         """
         Compute the derivative of K with respect to:
@@ -156,7 +153,6 @@ class StdPeriodic(Kern):
 
         return -F*np.sin(2*base)*self._clean_K(X, X2)
 
-    @Cache_this(limit=3, ignore_args=())
     def dK_dXdiag(self, X, dimX):
         """
         Compute the derivative of K with respect to:
@@ -166,7 +162,6 @@ class StdPeriodic(Kern):
         """
         return np.zeros(X.shape[0])
 
-    @Cache_this(limit=3, ignore_args=())
     def dK_dX2(self, X, X2, dimX2):
         """
         Compute the derivative of K with respect to:
@@ -174,7 +169,6 @@ class StdPeriodic(Kern):
         """
         return -self._clean_dK_dX(X, X2, dimX2)
 
-    @Cache_this(limit=3, ignore_args=())
     def dK_dX2diag(self, X, dimX2):
         """
         Compute the derivative of K with respect to:
@@ -184,7 +178,6 @@ class StdPeriodic(Kern):
         """
         return np.zeros(X.shape[0])
     
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dXdX2(self, X, X2, dimX, dimX2):
         """
         Compute the second derivative of K with respect to:
@@ -204,7 +197,6 @@ class StdPeriodic(Kern):
             term += 2*np.pi*periodinv*np.cos(2*base)*self._clean_K(X, X2)
         return F*term
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dXdX2diag(self, X, dimX, dimX2):
         """
         Compute the second derivative of K with respect to:
@@ -220,7 +212,6 @@ class StdPeriodic(Kern):
         else:
             return np.zeros(X.shape[0])
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dXdX(self, X, X2, dimX_0, dimX_1):
         """
         Compute the second derivative of K with respect to:
@@ -229,7 +220,6 @@ class StdPeriodic(Kern):
         """
         return -self._clean_dK2_dXdX2(X, X2, dimX_0, dimX_1)
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dXdXdiag(self, X, dimX_0, dimX_1):
         """
         Compute the second derivative of K with respect to:
@@ -240,7 +230,6 @@ class StdPeriodic(Kern):
         """
         return -self._clean_dK2_dXdX2diag(X, dimX_0, dimX_1)
 
-    @Cache_this(limit=3, ignore_args=())
     def dK3_dXdXdX2(self, X, X2, dimX_0, dimX_1, dimX2):
         """
         Compute the third derivative of K with respect to:
@@ -265,7 +254,6 @@ class StdPeriodic(Kern):
             term -= 4*(np.pi**2)*(periodinv**2)*np.sin(2*base)*self._clean_K(X, X2)
         return F*term
 
-    @Cache_this(limit=3, ignore_args=())
     def dK3_dXdXdX2diag(self, X, dimX_0, dimX_1, dimX2):
         """
         Compute the third derivative of K with respect to:
@@ -277,14 +265,12 @@ class StdPeriodic(Kern):
         """
         return np.zeros(X.shape[0])
 
-    @Cache_this(limit=3, ignore_args=())
     def dK_dvariance(self, X, X2):
         """
         Compute the derivative of K with respect to variance.
         """
         return self._clean_K(X, X2)/self.variance
 
-    @Cache_this(limit=3, ignore_args=())
     def dK_dlengthscale(self, X, X2):
         """
         Compute the derivative(s) of K with respect to lengthscale(s).
@@ -305,7 +291,6 @@ class StdPeriodic(Kern):
             g = (lengthscaleinv[0]**3)*np.sum(np.square(np.sin(base)), axis=0)*K
         return g
 
-    @Cache_this(limit=3, ignore_args=())
     def dK_dperiod(self, X, X2):
         """
         Compute the derivative(s) of K with respect to period(s).
@@ -326,7 +311,6 @@ class StdPeriodic(Kern):
             g = 0.5*periodinv[0]*np.sum(base*(lengthscaleinv**2)[:,None,None]*np.sin(2*base), axis=0)*K
         return g
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dvariancedX(self, X, X2, dimX):
         """
         Compute the second derivative of K with respect to:
@@ -335,7 +319,6 @@ class StdPeriodic(Kern):
         """
         return self._clean_dK_dX(X, X2, dimX)/self.variance
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dvariancedX2(self, X, X2, dimX2):
         """
         Compute the second derivative of K with respect to:
@@ -344,7 +327,6 @@ class StdPeriodic(Kern):
         """
         return -self.dK2_dvariancedX(X, X2, dimX2)
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dlengthscaledX(self, X, X2, dimX):
         """
         Compute the second derivative(s) of K with respect to:
@@ -373,7 +355,6 @@ class StdPeriodic(Kern):
             g = -F*np.sin(2*base)*(dK_dl - 2*lengthscaleinv*K)
         return g
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dlengthscaledX2(self, X, X2, dimX2):
         """
         Compute the second derivative(s) of K with respect to:
@@ -386,7 +367,6 @@ class StdPeriodic(Kern):
         else:
             return -1*dK2_dldX
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dperioddX(self, X, X2, dimX):
         """
         Compute the second derivative(s) of K with respect to:
@@ -417,7 +397,6 @@ class StdPeriodic(Kern):
             g = -F*term
         return g
 
-    @Cache_this(limit=3, ignore_args=())
     def dK2_dperioddX2(self, X, X2, dimX2):
         """
         Compute the second derivative(s) of K with respect to:
@@ -430,7 +409,6 @@ class StdPeriodic(Kern):
         else:
             return -1*dK2_dperioddX
 
-    @Cache_this(limit=3, ignore_args=())
     def dK3_dvariancedXdX2(self, X, X2, dimX, dimX2):
         """
         Compute the third derivative of K with respect to:
@@ -440,7 +418,6 @@ class StdPeriodic(Kern):
         """
         return self._clean_dK2_dXdX2(X, X2, dimX, dimX2)/self.variance
 
-    @Cache_this(limit=3, ignore_args=())
     def dK3_dlengthscaledXdX2(self, X, X2, dimX, dimX2):
         """
         Compute the third derivative(s) of K with respect to:
@@ -479,7 +456,6 @@ class StdPeriodic(Kern):
             g = term
         return g
 
-    @Cache_this(limit=3, ignore_args=())
     def dK3_dperioddXdX2(self, X, X2, dimX, dimX2):
         """
         Compute the third derivative(s) of K with respect to:

--- a/GPy/kern/src/standard_periodic.py
+++ b/GPy/kern/src/standard_periodic.py
@@ -266,12 +266,12 @@ class StdPeriodic(Kern):
         return F*term
 
     @Cache_this(limit=3, ignore_args=())
-    def dK3_dXdXdX2diag(self, X, dimX_0, dimX_1):
+    def dK3_dXdXdX2diag(self, X, dimX_0, dimX_1, dimX2):
         """
         Compute the third derivative of K with respect to:
             dimension dimX_0 of set X,
             dimension dimX_1 of set X, and
-            dimension dimX_1 of set X2.
+            dimension dimX2 of set X2.
 
         Returns only diagonal elements of the covariance matrix.
         """

--- a/GPy/kern/src/stationary.py
+++ b/GPy/kern/src/stationary.py
@@ -306,7 +306,12 @@ class Stationary(Kern):
         l4 =  np.ones(X.shape[1])*self.lengthscale**2
         return dL_dK_diag * (np.eye(X.shape[1]) * -self.dK2_drdr_diag()/(l4))[None, :,:]# np.zeros(X.shape+(X.shape[1],))
         #return np.ones(X.shape) * d2L_dK * self.variance/self.lengthscale**2 # np.zeros(X.shape)
-    
+
+    def dgradients(self, X, X2):
+        g1 = self.dK_dvariance(X, X2)
+        g2 = self.dK_dlengthscale(X, X2)
+        return [g1, g2]
+
     def dgradients_dX(self, X, X2, dimX):
         g1 = self.dK2_dvariancedX(X, X2, dimX)
         g2 = self.dK2_dlengthscaledX(X, X2, dimX)

--- a/GPy/testing/model_tests.py
+++ b/GPy/testing/model_tests.py
@@ -1407,7 +1407,7 @@ class GradientMultioutputGPTests(np.testing.TestCase):
         '''
         Testing gradient observing MultioutputGP model with several RBF kernels.
         '''
-        for D in range(2, 5):
+        for D in range(2, 4):
             kerns = [GPy.kern.RBF(input_dim=1) for d in range(D)]
             kern = reduce(lambda k0, k1: k0 * k1, kerns)
             kern.randomize()
@@ -1417,7 +1417,7 @@ class GradientMultioutputGPTests(np.testing.TestCase):
         '''
         Testing gradient observing MultioutputGP model with several StdP kernels.
         '''
-        for D in range(2, 5):
+        for D in range(2, 4):
             kerns = [GPy.kern.StdPeriodic(input_dim=1, period=self.period) for d in range(D)]
             kern = reduce(lambda k0, k1: k0 * k1, kerns)
             [k.period.constrain_fixed() for k in kern.parts]
@@ -1428,7 +1428,7 @@ class GradientMultioutputGPTests(np.testing.TestCase):
         '''
         Testing gradient observing MultioutputGP model with a mix of kernel types.
         '''
-        for D in range(2, 5):
+        for D in range(2, 4):
             kerns = []
             for d in range(D):
                 if d % 2 == 0:

--- a/GPy/testing/model_tests.py
+++ b/GPy/testing/model_tests.py
@@ -1316,11 +1316,15 @@ class GradientObservingModelTests(np.testing.TestCase):
         # create model and check its hyperparameter gradient
         likelihood_list = [GPy.likelihoods.Gaussian(variance=self.noise_std**2)]*(D + 1)
         model = GPy.models.MultioutputGP(X_list, Y_list, kernel_list, likelihood_list)
+        model.likelihood.constrain_fixed()
         self.assertTrue(model.checkgrad())
 
         # optimize the model, and check its hyperparameter gradient again
         model.optimize()
         self.assertTrue(model.checkgrad())
+
+        # check predictions
+        np.testing.assert_allclose(model.predict(X_list)[0], model.Y, atol=self.noise_std)
 
         # test input for checking predictive gradients
         ppa = int(np.round(np.power(self.test_points, 1/D))) # points per axis


### PR DESCRIPTION
Pull request to enhance the feature of including gradient observations in GPy. This request builds on the previously merged [request #678](https://github.com/SheffieldML/GPy/pull/678) by @esiivola, that established the framework. GPy is used by the [BOSS](https://gitlab.com/cest-group/boss) code for materials optimization, and there is strong interest in the gradient observation feature. This is a collaboration between the groups of Prof. Aki Vehtari (Aalto University) and Eero Siivola, with Prof. Patrick Rinke (Aalto University) and Prof. Milica Todorović (University of Turku).

Currently in the most recent version of GPy (devel), only the RBF kernel can be used with models that incorporate gradient information. This PR will introduce the following features:

- The StdPeriodic kernel can now be used with models that incorporate gradient information
- The Prod kernel can now be used with models that incorporate gradient information (at present, this works only with RBF and StdP kernels, but can in principle be extended to other kernel types)
- MultioutputGP models augmented with gradient information now allow for the computation of the gradients of predicted posterior means and variances
- Added unit-testing framework for MultioutputGP models augmented with gradient information

The previous pull request was reviewed by @mzwiessele, maybe he would like to review this one as well if he is available.