### PR TITLE
Fix issues encountered in modern python versions

### DIFF
--- a/GPy/core/__init__.py
+++ b/GPy/core/__init__.py
@@ -77,7 +77,7 @@ def randomize(self, rand_gen=None, *args, **kwargs):
     # now draw from prior where possible
     x = self.param_array.copy()
     [np.put(x, ind, p.rvs(ind.size)) for p, ind in self.priors.items() if not p is None]
-    unfixlist = np.ones((self.size,),dtype=np.bool)
+    unfixlist = np.ones((self.size,),dtype=bool)
     from paramz.transformations import __fixed__
     unfixlist[self.constraints[__fixed__]] = False
     self.param_array.flat[unfixlist] = x.view(np.ndarray).ravel()[unfixlist]

--- a/GPy/inference/mcmc/samplers.py
+++ b/GPy/inference/mcmc/samplers.py
@@ -38,7 +38,7 @@ class Metropolis_Hastings(object):
     def sample(self, Ntotal=10000, Nburn=1000, Nthin=10, tune=True, tune_throughout=False, tune_interval=400):
         current = self.model.optimizer_array
         fcurrent = self.model.log_likelihood() + self.model.log_prior() 
-        accepted = np.zeros(Ntotal,dtype=np.bool)
+        accepted = np.zeros(Ntotal,dtype=bool)
         for it in range(Ntotal):
             print("sample %d of %d\r"%(it+1,Ntotal),end="")
             sys.stdout.flush()

--- a/GPy/plotting/matplot_dep/base_plots.py
+++ b/GPy/plotting/matplot_dep/base_plots.py
@@ -82,9 +82,9 @@ def gradient_fill(x, percentiles, ax=None, fignum=None, **kwargs):
             y2 = np.ones_like(x) * y2
 
         if where is None:
-            where = np.ones(len(x), np.bool)
+            where = np.ones(len(x), bool)
         else:
-            where = np.asarray(where, np.bool)
+            where = np.asarray(where, bool)
 
         if not (x.shape == y1.shape == y2.shape == where.shape):
             raise ValueError("Argument dimensions are incompatible")

--- a/GPy/plotting/matplot_dep/plot_definitions.py
+++ b/GPy/plotting/matplot_dep/plot_definitions.py
@@ -255,9 +255,9 @@ class MatplotlibPlots(AbstractPlottingLibrary):
                 y2 = np.ones_like(x) * y2
 
             if where is None:
-                where = np.ones(len(x), np.bool)
+                where = np.ones(len(x), bool)
             else:
-                where = np.asarray(where, np.bool)
+                where = np.asarray(where, bool)
 
             if not (x.shape == y1.shape == y2.shape == where.shape):
                 raise ValueError("Argument dimensions are incompatible")

--- a/setup.py
+++ b/setup.py
@@ -119,11 +119,7 @@ except ModuleNotFoundError:
 
 install_requirements = ['numpy>=1.7', 'six', 'paramz>=0.9.0', 'cython>=0.29']
 matplotlib_version = 'matplotlib==3.3.4'
-if sys.version_info < (3, 6):
-    install_requirements += ['scipy>=1.3.0,<1.5.0']
-    matplotlib_version = 'matplotlib==3.0.0'
-else:
-    install_requirements += ['scipy>=1.3.0']
+install_requirements += ['scipy>=1.3.0']
 
 setup(name = 'GPy',
       version = __version__,


### PR DESCRIPTION
The constraints on the `scipy` version are quite restrictive and seem to cause linker errors on blas/lapack when combined with modern `numpy` versions.

Also, datatype `np.bool` does not exist in modern `numpy` versions, while `bool` exists for all python versions.