### PR TITLE
Fix deprecated function readfp

### DIFF
--- a/GPy/util/config.py
+++ b/GPy/util/config.py
@@ -25,7 +25,7 @@ home = os.getenv('HOME') or os.getenv('USERPROFILE') or ''
 user_file = os.path.join(home,'.config','GPy', 'user.cfg')
 
 # Read in the given files.
-config.readfp(open(default_file))
+config.read_file(open(default_file))
 config.read([local_file, user_file])
 
 if not config:


### PR DESCRIPTION
Since Python 3.2 function readfp is replaced with read_file: [python documentation](https://docs.python.org/3.12/library/configparser.html#configparser.ConfigParser.read_file) 

Readfp was fully removed in Python 3.12 so this fix is needed for GPy.