### PR TITLE
remove python2-styled print statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* remove python2-style print statements (#1056)
+
 * update import in `.plotting.matplot_dep.defaults` due to change in matplotlib
 
 * Correct dl_dm term in student t inference #1065

--- a/GPy/testing/deactivated/deactivated_test_mpi.py
+++ b/GPy/testing/deactivated/deactivated_test_mpi.py
@@ -23,11 +23,11 @@ infr = GPy.inference.latent_function_inference.VarDTC_minibatch(mpi_comm=comm)
 m = GPy.models.BayesianGPLVM(data.T,1,mpi_comm=comm)
 m.optimize(max_iters=10)
 if comm.rank==0:
-    print float(m.objective_function())
+    print(float(m.objective_function()))
     m.inference_method.mpi_comm=None
     m.mpi_comm=None
     m._trigger_params_changed()
-    print float(m.objective_function())
+    print(float(m.objective_function()))
             """
             with open("mpi_test__.py", "w") as f:
                 f.write(code)
@@ -59,11 +59,11 @@ data = np.vstack([x,y])
 m = GPy.models.SparseGPRegression(data[:1].T,data[1:2].T,mpi_comm=comm)
 m.optimize(max_iters=10)
 if comm.rank==0:
-    print float(m.objective_function())
+    print(float(m.objective_function()))
     m.inference_method.mpi_comm=None
     m.mpi_comm=None
     m._trigger_params_changed()
-    print float(m.objective_function())
+    print(float(m.objective_function()))
             """
             with open("mpi_test__.py", "w") as f:
                 f.write(code)

--- a/GPy/testing/mpi_test__.py
+++ b/GPy/testing/mpi_test__.py
@@ -1,21 +1,20 @@
-
 import numpy as np
 import GPy
 from mpi4py import MPI
+
 np.random.seed(123456)
 comm = MPI.COMM_WORLD
 N = 100
-x = np.linspace(-6., 6., N)
+x = np.linspace(-6.0, 6.0, N)
 y = np.sin(x) + np.random.randn(N) * 0.05
 comm.Bcast(y)
-data = np.vstack([x,y])
-#infr = GPy.inference.latent_function_inference.VarDTC_minibatch(mpi_comm=comm)
-m = GPy.models.SparseGPRegression(data[:1].T,data[1:2].T,mpi_comm=comm)
+data = np.vstack([x, y])
+# infr = GPy.inference.latent_function_inference.VarDTC_minibatch(mpi_comm=comm)
+m = GPy.models.SparseGPRegression(data[:1].T, data[1:2].T, mpi_comm=comm)
 m.optimize(max_iters=10)
-if comm.rank==0:
-    print float(m.objective_function())
-    m.inference_method.mpi_comm=None
-    m.mpi_comm=None
+if comm.rank == 0:
+    print(float(m.objective_function()))
+    m.inference_method.mpi_comm = None
+    m.mpi_comm = None
     m._trigger_params_changed()
-    print float(m.objective_function())
-            
+    print(float(m.objective_function()))

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,33 +19,35 @@ import shlex
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#for p in os.walk('../../GPy'):
+# for p in os.walk('../../GPy'):
 #    sys.path.append(p[0])
-sys.path.insert(0, os.path.abspath('../../'))
-sys.path.insert(0, os.path.abspath('../../GPy/'))
+sys.path.insert(0, os.path.abspath("../../"))
+sys.path.insert(0, os.path.abspath("../../GPy/"))
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 import sys
 from unittest.mock import MagicMock
+
 
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):
         return MagicMock()
 
+
 MOCK_MODULES = [
     "GPy.util.linalg.linalg_cython",
     "GPy.util.linalg_cython",
     "sympy",
-    'GPy.kern.stationary_cython',
+    "GPy.kern.stationary_cython",
     "sympy.utilities",
     "sympy.utilities.lambdify",
 ]
 
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
-#on_rtd = True
+# on_rtd = True
 if on_rtd:
     # sys.path.append(os.path.abspath('../GPy'))
 
@@ -63,8 +65,10 @@ if on_rtd:
     print("$ pwd: ")
     print(out)
 
-    #Lets regenerate our rst files from the source, -P adds private modules (i.e kern._src)
-    proc = subprocess.Popen("sphinx-apidoc -M -P -f -o . ../../GPy", stdout=subprocess.PIPE, shell=True)
+    # Lets regenerate our rst files from the source, -P adds private modules (i.e kern._src)
+    proc = subprocess.Popen(
+        "sphinx-apidoc -M -P -f -o . ../../GPy", stdout=subprocess.PIPE, shell=True
+    )
     (out, err) = proc.communicate()
     print("$ Apidoc:")
     print(out)
@@ -73,84 +77,88 @@ if on_rtd:
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
+    "sphinx.ext.autodoc",
     #'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.graphviz',
-    'sphinx.ext.inheritance_diagram',
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.graphviz",
+    "sphinx.ext.inheritance_diagram",
 ]
 
-#---sphinx.ext.inheritance_diagram config
+# ---sphinx.ext.inheritance_diagram config
 inheritance_graph_attrs = dict(rankdir="LR", dpi=1200)
 
-#----- Autodoc
-#import sys
-#try:
+# ----- Autodoc
+# import sys
+# try:
 #    from unittest.mock import MagicMock
-#except:
+# except:
 #    from mock import Mock as MagicMock
 #
-#class Mock(MagicMock):
+# class Mock(MagicMock):
 #    @classmethod
 #    def __getattr__(cls, name):
 #            return Mock()
 #
 #
-#sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+# sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 #
 import sphinx_rtd_theme
 
-autodoc_default_flags = ['members',
-                         #'undoc-members',
-                         #'private-members',
-                         #'special-members',
-                         #'inherited-members',
-                         'show-inheritance']
+autodoc_default_flags = [
+    "members",
+    #'undoc-members',
+    #'private-members',
+    #'special-members',
+    #'inherited-members',
+    "show-inheritance",
+]
 
-autodoc_member_order = 'groupwise'
+autodoc_member_order = "groupwise"
 add_function_parentheses = False
 add_module_names = False
-#modindex_common_prefix = ['GPy']
+# modindex_common_prefix = ['GPy']
 show_authors = True
 
 # ------ Sphinx
 # Add any paths that contain templates here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]#templates_path = ['_templates']
+html_theme_path = [
+    sphinx_rtd_theme.get_html_theme_path()
+]  # templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'GPy'
-#author = u'`Humans <https://github.com/SheffieldML/GPy/graphs/contributors>`_'
-author = 'GPy Authors, see https://github.com/SheffieldML/GPy/graphs/contributors'
-copyright = u'2020, '+author
+project = "GPy"
+# author = u'`Humans <https://github.com/SheffieldML/GPy/graphs/contributors>`_'
+author = "GPy Authors, see https://github.com/SheffieldML/GPy/graphs/contributors"
+copyright = "2020, " + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-with open('../../GPy/__version__.py', 'r') as f:
+with open("../../GPy/__version__.py", "r") as f:
     version = f.read()
     release = version
 
-print version
+print(version)
 
 # version = '0.8.8'
 # The full version, including alpha/beta/rc tags.
@@ -161,27 +169,29 @@ print version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'python'
+language = "python"
 
 # autodoc:
-autoclass_content = 'both'
-autodoc_default_flags = ['members',
-                         #'undoc-members',
-                         #'private-members',
-                         #'special-members',
-                         #'inherited-members',
-                         'show-inheritance']
-autodoc_member_order = 'groupwise'
+autoclass_content = "both"
+autodoc_default_flags = [
+    "members",
+    #'undoc-members',
+    #'private-members',
+    #'special-members',
+    #'inherited-members',
+    "show-inheritance",
+]
+autodoc_member_order = "groupwise"
 add_function_parentheses = False
 add_module_names = False
-modindex_common_prefix = ['paramz']
+modindex_common_prefix = ["paramz"]
 show_authors = True
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -189,27 +199,27 @@ exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -219,62 +229,62 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = dict(sidebarwidth='20}
+# html_theme_options = dict(sidebarwidth='20}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_css_files = [
-    'wide.css',
+    "wide.css",
 ]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {
+# html_sidebars = {
 #   '**': ['globaltoc.html', 'localtoc.html', 'sourcelink.html', 'searchbox.html'],
 #   'using/windows': ['windowssidebar.html', 'searchbox.html'],
-#}
+# }
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
 html_domain_indices = False
@@ -289,92 +299,89 @@ html_split_index = True
 html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'GPydoc'
+htmlhelp_basename = "GPydoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-'papersize': 'a4paper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    "papersize": "a4paper",
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+    # Latex figure (float) alignment
+    "figure_align": "htbp",
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-#latex_documents = [
+# latex_documents = [
 #  (master_doc, 'GPy.tex', u'GPy Documentation',
 #   u'GPy Authors', 'manual'),
-#]
+# ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-#man_pages = [
+# man_pages = [
 #    (master_doc, 'gpy', u'GPy Documentation',
 #     [author], 1)
-#]
+# ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -382,20 +389,20 @@ latex_elements = {
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
-#texinfo_documents = [
+# texinfo_documents = [
 #  (master_doc, 'GPy', u'GPy Documentation',
 #   author, 'GPy', 'One line description of project.',
 #   'Miscellaneous'),
-#]
+# ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False


### PR DESCRIPTION
Not much to say here. There were some leftovers from the last modernization patch that still used python2-styled `print something` instead of `print(something)`.