### PR TITLE
downgrad actions on manylinux build job

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -223,7 +223,7 @@ jobs:
         run: ls -R dist
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v1
         with:
           name: dist-artifacts-manylinux-${{ matrix.python }}
           path: dist/*

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -223,7 +223,7 @@ jobs:
         run: ls -R dist
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: dist-artifacts-manylinux-${{ matrix.python }}
           path: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 
 * update dependencies to `numpy>=1.7.0,<2.0.0`
 
-* update dependencies to `numpy>=1.7.0,<2.0.0`
-
 * update import in `.plotting.matplot_dep.defaults` due to change in matplotlib
 
 * Correct dl_dm term in student t inference #1065


### PR DESCRIPTION
The versions for upload-artifact and checkout as used before were causing glibc failures on the used manylinux container, preventing the deploy pipeline