### PR TITLE
add ruff pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.7.1
+  hooks:
+    # Run the linter.
+    - id: ruff
+      types_or: [ python, pyi ]
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      types_or: [ python, pyi ]


### PR DESCRIPTION
Comes at a "problem": ruff identifies almost 800 errors than cannot be fixed automatically and require user interaction.

This is quite tedious and I cannot address it atm as it is just too much work.
Running ruff with `--unsafe-fixes` brings that number down to just 255 files, but I do not feel comfortable with simply applying those potentially unsafe operations as I am not sure whether the tesitng lib covers all potential issues.

@janmayer any idea / input / experience on this?