### PR TITLE
limit upper pytest version in workflows

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install matplotlib
-          pip install pytest<8
+          pip install 'pytest<8'
 
       - name: pytest
         run: |

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install matplotlib
-          pip install pytest<8
+          pip install 'pytest<8'
 
       - name: pytest
         run: |

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install matplotlib
-          pip install pytest<8
+          pip install 'pytest<8'
 
       - name: pytest
         run: |

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install matplotlib
-          pip install pytest
+          pip install pytest<8
 
       - name: pytest
         run: |
@@ -71,7 +71,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install matplotlib
-          pip install pytest
+          pip install pytest<8
 
       - name: pytest
         run: |
@@ -103,7 +103,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install matplotlib
-          pip install pytest
+          pip install pytest<8
 
       - name: pytest
         run: |


### PR DESCRIPTION
pytest>=8.0 causes errors with the existing tests, resulting in broken pipelines